### PR TITLE
Enable docker-compose env overrides

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Database connection string used by the API and MQTT services.
+DATABASE_URL=mysql://root:password@database:3306/meshtastic-map?connection_limit=100
+
+# Override the HTTP port exposed by the API service inside the container.
+API_HTTP_PORT=80
+
+# MQTT broker connection details for the MQTT service.
+MQTT_URL=mqtt://mqtt.meshnet.si
+MQTT_PROTOCOL=mqtt
+MQTT_USERNAME=slovenia
+MQTT_PASSWORD=meshnet-si-slovenia
+MQTT_CLIENT_ID=map.meshnet.si
+MQTT_TOPIC=si/#
+
+# MariaDB credentials used by the database service.
+MARIADB_DATABASE=meshtastic-map
+MARIADB_ROOT_PASSWORD=password

--- a/README.md
+++ b/README.md
@@ -58,11 +58,14 @@ Compila le immagini Docker:
 docker compose -f docker-compose.dev.yaml build
 ```
 
-Aggiorna le variabili d'ambiente:
+Configura le variabili d'ambiente copiando il file di esempio e modificandolo se necessario:
 
 ```
-nano docker-compose.yaml
+cp .env.example .env
+nano .env
 ```
+
+Il file `.env.example` elenca tutte le variabili supportate; Docker Compose leggerà automaticamente i valori definiti in `.env`.
 
 Elenco variabili d'ambiente:
 
@@ -91,11 +94,14 @@ Compila le immagini Docker:
 docker compose build
 ```
 
-Aggiorna le variabili d'ambiente:
+Configura le variabili d'ambiente copiando il file di esempio e modificandolo se necessario:
 
 ```
-nano docker-compose.yaml
+cp .env.example .env
+nano .env
 ```
+
+Il file `.env.example` elenca tutte le variabili supportate; Docker Compose leggerà automaticamente i valori definiti in `.env`.
 
 Elenco variabili d'ambiente:
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -27,7 +27,8 @@ services:
     ports:
       - 8081:80
     environment:
-      DATABASE_URL: "mysql://root:password@database:3306/meshtastic-map?connection_limit=100"
+      DATABASE_URL: "${DATABASE_URL:-mysql://root:password@database:3306/meshtastic-map?connection_limit=100}"
+      HTTP_PORT: "${API_HTTP_PORT:-80}"
     volumes:
       - ./api:/app
       - ./prisma:/app/prisma
@@ -42,7 +43,13 @@ services:
       database:
         condition: service_healthy
     environment:
-      DATABASE_URL: "mysql://root:password@database:3306/meshtastic-map?connection_limit=100"
+      DATABASE_URL: "${DATABASE_URL:-mysql://root:password@database:3306/meshtastic-map?connection_limit=100}"
+      MQTT_URL: "${MQTT_URL:-mqtt://mqtt.meshnet.si}"
+      MQTT_PROTOCOL: "${MQTT_PROTOCOL:-mqtt}"
+      MQTT_USERNAME: "${MQTT_USERNAME:-slovenia}"
+      MQTT_PASSWORD: "${MQTT_PASSWORD:-meshnet-si-slovenia}"
+      MQTT_CLIENT_ID: "${MQTT_CLIENT_ID:-map.meshnet.si}"
+      MQTT_TOPIC: "${MQTT_TOPIC:-si/#}"
     volumes:
       - ./mqtt:/app
       - ./prisma:/app/prisma
@@ -52,8 +59,8 @@ services:
     container_name: database
     image: bitnami/mariadb
     environment:
-      MARIADB_DATABASE: "meshtastic-map"
-      MARIADB_ROOT_PASSWORD: "password"
+      MARIADB_DATABASE: "${MARIADB_DATABASE:-meshtastic-map}"
+      MARIADB_ROOT_PASSWORD: "${MARIADB_ROOT_PASSWORD:-password}"
     ports:
       - 3306:3306/tcp
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,7 +20,8 @@ services:
       database:
         condition: service_healthy
     environment:
-      DATABASE_URL: "mysql://root:password@database:3306/meshtastic-map?connection_limit=100"
+      DATABASE_URL: "${DATABASE_URL:-mysql://root:password@database:3306/meshtastic-map?connection_limit=100}"
+      HTTP_PORT: "${API_HTTP_PORT:-80}"
 
   # listens to mqtt packets and saves to database
   mqtt:
@@ -32,15 +33,21 @@ services:
       database:
         condition: service_healthy
     environment:
-      DATABASE_URL: "mysql://root:password@database:3306/meshtastic-map?connection_limit=100"
+      DATABASE_URL: "${DATABASE_URL:-mysql://root:password@database:3306/meshtastic-map?connection_limit=100}"
+      MQTT_URL: "${MQTT_URL:-mqtt://mqtt.meshnet.si}"
+      MQTT_PROTOCOL: "${MQTT_PROTOCOL:-mqtt}"
+      MQTT_USERNAME: "${MQTT_USERNAME:-slovenia}"
+      MQTT_PASSWORD: "${MQTT_PASSWORD:-meshnet-si-slovenia}"
+      MQTT_CLIENT_ID: "${MQTT_CLIENT_ID:-map.meshnet.si}"
+      MQTT_TOPIC: "${MQTT_TOPIC:-si/#}"
 
   # runs the database to store everything from mqtt
   database:
     container_name: database
     image: bitnami/mariadb
     environment:
-      MARIADB_DATABASE: "meshtastic-map"
-      MARIADB_ROOT_PASSWORD: "password"
+      MARIADB_DATABASE: "${MARIADB_DATABASE:-meshtastic-map}"
+      MARIADB_ROOT_PASSWORD: "${MARIADB_ROOT_PASSWORD:-password}"
     volumes:
       - database_data:/bitnami/mariadb
     healthcheck:


### PR DESCRIPTION
## Summary
- allow overriding API, MQTT and database settings via Docker Compose environment variables with sensible defaults
- add a reusable `.env.example` file and document the new workflow in the README

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8a822521883239a12731f3c84c012