### PR TITLE
Extend metrics history ranges and disable power purge

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -1330,13 +1330,19 @@
 										<div class="flex bg-gray-200 p-2 font-semibold">
 											<div class="my-auto">Device Metrics</div>
 											<div class="my-auto ml-auto">
-												<select
-													v-model="deviceMetricsTimeRange"
-													class="block w-full rounded-md border-0 py-0.5 pl-2 pr-8 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-blue-500 sm:text-sm sm:leading-6">
-													<option value="1d">1 Day</option>
-													<option value="3d">3 Days</option>
-													<option value="7d">7 Days</option>
-												</select>
+                                                                                                <select
+                                                                                                        v-model="deviceMetricsTimeRange"
+                                                                                                        class="block w-full rounded-md border-0 py-0.5 pl-2 pr-8 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-blue-500 sm:text-sm sm:leading-6">
+                                                                                                        <option value="1d">1 Day</option>
+                                                                                                        <option value="3d">3 Days</option>
+                                                                                                        <option value="7d">7 Days</option>
+                                                                                                        <option value="14d">14 Days</option>
+                                                                                                        <option value="30d">30 Days</option>
+                                                                                                        <option value="90d">90 Days</option>
+                                                                                                        <option value="180d">180 Days</option>
+                                                                                                        <option value="365d">365 Days</option>
+                                                                                                        <option value="all">All Data</option>
+                                                                                                </select>
 											</div>
 										</div>
 										<ul role="list" class="flex-1 divide-y divide-gray-200">
@@ -1461,13 +1467,19 @@
 										<div class="flex bg-gray-200 p-2 font-semibold">
 											<div class="my-auto">Environment Metrics</div>
 											<div class="my-auto ml-auto">
-												<select
-													v-model="environmentMetricsTimeRange"
-													class="block w-full rounded-md border-0 py-0.5 pl-2 pr-8 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-blue-500 sm:text-sm sm:leading-6">
-													<option value="1d">1 Day</option>
-													<option value="3d">3 Days</option>
-													<option value="7d">7 Days</option>
-												</select>
+                                                                                                <select
+                                                                                                        v-model="environmentMetricsTimeRange"
+                                                                                                        class="block w-full rounded-md border-0 py-0.5 pl-2 pr-8 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-blue-500 sm:text-sm sm:leading-6">
+                                                                                                        <option value="1d">1 Day</option>
+                                                                                                        <option value="3d">3 Days</option>
+                                                                                                        <option value="7d">7 Days</option>
+                                                                                                        <option value="14d">14 Days</option>
+                                                                                                        <option value="30d">30 Days</option>
+                                                                                                        <option value="90d">90 Days</option>
+                                                                                                        <option value="180d">180 Days</option>
+                                                                                                        <option value="365d">365 Days</option>
+                                                                                                        <option value="all">All Data</option>
+                                                                                                </select>
 											</div>
 										</div>
 										<ul role="list" class="flex-1 divide-y divide-gray-200">
@@ -1561,13 +1573,19 @@
 										<div class="flex bg-gray-200 p-2 font-semibold">
 											<div class="my-auto">Power Metrics</div>
 											<div class="my-auto ml-auto">
-												<select
-													v-model="powerMetricsTimeRange"
-													class="block w-full rounded-md border-0 py-0.5 pl-2 pr-8 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-blue-500 sm:text-sm sm:leading-6">
-													<option value="1d">1 Day</option>
-													<option value="3d">3 Days</option>
-													<option value="7d">7 Days</option>
-												</select>
+                                                                                                <select
+                                                                                                        v-model="powerMetricsTimeRange"
+                                                                                                        class="block w-full rounded-md border-0 py-0.5 pl-2 pr-8 text-gray-900 ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-blue-500 sm:text-sm sm:leading-6">
+                                                                                                        <option value="1d">1 Day</option>
+                                                                                                        <option value="3d">3 Days</option>
+                                                                                                        <option value="7d">7 Days</option>
+                                                                                                        <option value="14d">14 Days</option>
+                                                                                                        <option value="30d">30 Days</option>
+                                                                                                        <option value="90d">90 Days</option>
+                                                                                                        <option value="180d">180 Days</option>
+                                                                                                        <option value="365d">365 Days</option>
+                                                                                                        <option value="all">All Data</option>
+                                                                                                </select>
 											</div>
 										</div>
 										<ul role="list" class="flex-1 divide-y divide-gray-200">
@@ -2808,8 +2826,21 @@
 			}
 		</script>
 
-		<script>
-			Vue.createApp({
+                <script>
+                        const METRIC_TIME_RANGE_DAYS = {
+                                "1d": 1,
+                                "3d": 3,
+                                "7d": 7,
+                                "14d": 14,
+                                "30d": 30,
+                                "90d": 90,
+                                "180d": 180,
+                                "365d": 365,
+                        };
+                        const DEFAULT_METRIC_TIME_RANGE = "3d";
+                        const MILLISECONDS_PER_DAY = 86400 * 1000;
+
+                        Vue.createApp({
 				data() {
 					return {
 						isShowingAnnouncement: this.shouldShowAnnouncement(),
@@ -2937,37 +2968,34 @@
 								// do nothing
 							});
 					},
-					loadNodeDeviceMetrics: function (nodeId) {
-						// calculate unix timestamps in milliseconds for supported time ranges
-						const oneDayAgoInMilliseconds = new Date().getTime() - 86400 * 1000;
-						const threeDaysAgoInMilliseconds =
-							new Date().getTime() - 259200 * 1000;
-						const sevenDaysAgoInMilliseconds =
-							new Date().getTime() - 604800 * 1000;
+                                        loadNodeDeviceMetrics: function (nodeId) {
+                                                if (nodeId == null) {
+                                                        return;
+                                                }
 
-						// determine how long back to load device metrics from
-						var timeFrom = threeDaysAgoInMilliseconds;
-						switch (this.deviceMetricsTimeRange) {
-							case "1d": {
-								timeFrom = oneDayAgoInMilliseconds;
-								break;
-							}
-							case "3d": {
-								timeFrom = threeDaysAgoInMilliseconds;
-								break;
-							}
-							case "7d": {
-								timeFrom = sevenDaysAgoInMilliseconds;
-								break;
-							}
-						}
+                                                const selectedRange =
+                                                        this.deviceMetricsTimeRange ||
+                                                        DEFAULT_METRIC_TIME_RANGE;
+                                                let timeFrom = null;
 
-						window.axios
-							.get(`/api/v1/nodes/${nodeId}/device-metrics`, {
-								params: {
-									time_from: timeFrom,
-								},
-							})
+                                                if (selectedRange !== "all") {
+                                                        const selectedDays =
+                                                                METRIC_TIME_RANGE_DAYS[selectedRange] ??
+                                                                METRIC_TIME_RANGE_DAYS[DEFAULT_METRIC_TIME_RANGE];
+                                                        timeFrom =
+                                                                Date.now() -
+                                                                selectedDays * MILLISECONDS_PER_DAY;
+                                                }
+
+                                                const params = {};
+                                                if (timeFrom != null) {
+                                                        params.time_from = timeFrom;
+                                                }
+
+                                                window.axios
+                                                        .get(`/api/v1/nodes/${nodeId}/device-metrics`, {
+                                                                params,
+                                                        })
 							.then((response) => {
 								// reverse response, as it's newest to oldest, but we want oldest to newest
 								this.selectedNodeDeviceMetrics =
@@ -2979,37 +3007,34 @@
 								this.renderDeviceMetricCharts();
 							});
 					},
-					loadNodeEnvironmentMetrics: function (nodeId) {
-						// calculate unix timestamps in milliseconds for supported time ranges
-						const oneDayAgoInMilliseconds = new Date().getTime() - 86400 * 1000;
-						const threeDaysAgoInMilliseconds =
-							new Date().getTime() - 259200 * 1000;
-						const sevenDaysAgoInMilliseconds =
-							new Date().getTime() - 604800 * 1000;
+                                        loadNodeEnvironmentMetrics: function (nodeId) {
+                                                if (nodeId == null) {
+                                                        return;
+                                                }
 
-						// determine how long back to load environment metrics from
-						var timeFrom = threeDaysAgoInMilliseconds;
-						switch (this.environmentMetricsTimeRange) {
-							case "1d": {
-								timeFrom = oneDayAgoInMilliseconds;
-								break;
-							}
-							case "3d": {
-								timeFrom = threeDaysAgoInMilliseconds;
-								break;
-							}
-							case "7d": {
-								timeFrom = sevenDaysAgoInMilliseconds;
-								break;
-							}
-						}
+                                                const selectedRange =
+                                                        this.environmentMetricsTimeRange ||
+                                                        DEFAULT_METRIC_TIME_RANGE;
+                                                let timeFrom = null;
 
-						window.axios
-							.get(`/api/v1/nodes/${nodeId}/environment-metrics`, {
-								params: {
-									time_from: timeFrom,
-								},
-							})
+                                                if (selectedRange !== "all") {
+                                                        const selectedDays =
+                                                                METRIC_TIME_RANGE_DAYS[selectedRange] ??
+                                                                METRIC_TIME_RANGE_DAYS[DEFAULT_METRIC_TIME_RANGE];
+                                                        timeFrom =
+                                                                Date.now() -
+                                                                selectedDays * MILLISECONDS_PER_DAY;
+                                                }
+
+                                                const params = {};
+                                                if (timeFrom != null) {
+                                                        params.time_from = timeFrom;
+                                                }
+
+                                                window.axios
+                                                        .get(`/api/v1/nodes/${nodeId}/environment-metrics`, {
+                                                                params,
+                                                        })
 							.then((response) => {
 								// reverse response, as it's newest to oldest, but we want oldest to newest
 								this.selectedNodeEnvironmentMetrics =
@@ -3021,37 +3046,33 @@
 								this.renderEnvironmentMetricCharts();
 							});
 					},
-					loadNodePowerMetrics: function (nodeId) {
-						// calculate unix timestamps in milliseconds for supported time ranges
-						const oneDayAgoInMilliseconds = new Date().getTime() - 86400 * 1000;
-						const threeDaysAgoInMilliseconds =
-							new Date().getTime() - 259200 * 1000;
-						const sevenDaysAgoInMilliseconds =
-							new Date().getTime() - 604800 * 1000;
+                                        loadNodePowerMetrics: function (nodeId) {
+                                                if (nodeId == null) {
+                                                        return;
+                                                }
 
-						// determine how long back to load power metrics from
-						var timeFrom = threeDaysAgoInMilliseconds;
-						switch (this.powerMetricsTimeRange) {
-							case "1d": {
-								timeFrom = oneDayAgoInMilliseconds;
-								break;
-							}
-							case "3d": {
-								timeFrom = threeDaysAgoInMilliseconds;
-								break;
-							}
-							case "7d": {
-								timeFrom = sevenDaysAgoInMilliseconds;
-								break;
-							}
-						}
+                                                const selectedRange =
+                                                        this.powerMetricsTimeRange || DEFAULT_METRIC_TIME_RANGE;
+                                                let timeFrom = null;
 
-						window.axios
-							.get(`/api/v1/nodes/${nodeId}/power-metrics`, {
-								params: {
-									time_from: timeFrom,
-								},
-							})
+                                                if (selectedRange !== "all") {
+                                                        const selectedDays =
+                                                                METRIC_TIME_RANGE_DAYS[selectedRange] ??
+                                                                METRIC_TIME_RANGE_DAYS[DEFAULT_METRIC_TIME_RANGE];
+                                                        timeFrom =
+                                                                Date.now() -
+                                                                selectedDays * MILLISECONDS_PER_DAY;
+                                                }
+
+                                                const params = {};
+                                                if (timeFrom != null) {
+                                                        params.time_from = timeFrom;
+                                                }
+
+                                                window.axios
+                                                        .get(`/api/v1/nodes/${nodeId}/power-metrics`, {
+                                                                params,
+                                                        })
 							.then((response) => {
 								// reverse response, as it's newest to oldest, but we want oldest to newest
 								this.selectedNodePowerMetrics =
@@ -3801,15 +3822,29 @@
 					configTemperatureFormat() {
 						window.setConfigTemperatureFormat(this.configTemperatureFormat);
 					},
-					deviceMetricsTimeRange() {
-						this.loadNodeDeviceMetrics(this.selectedNode.node_id);
-					},
-					environmentMetricsTimeRange() {
-						this.loadNodeEnvironmentMetrics(this.selectedNode.node_id);
-					},
-					powerMetricsTimeRange() {
-						this.loadNodePowerMetrics(this.selectedNode.node_id);
-					},
+                                        deviceMetricsTimeRange() {
+                                                if (!this.selectedNode) {
+                                                        return;
+                                                }
+
+                                                this.loadNodeDeviceMetrics(this.selectedNode.node_id);
+                                        },
+                                        environmentMetricsTimeRange() {
+                                                if (!this.selectedNode) {
+                                                        return;
+                                                }
+
+                                                this.loadNodeEnvironmentMetrics(
+                                                        this.selectedNode.node_id,
+                                                );
+                                        },
+                                        powerMetricsTimeRange() {
+                                                if (!this.selectedNode) {
+                                                        return;
+                                                }
+
+                                                this.loadNodePowerMetrics(this.selectedNode.node_id);
+                                        },
 				},
 			}).mount("#app");
 		</script>

--- a/mqtt/src/settings.ts
+++ b/mqtt/src/settings.ts
@@ -6,10 +6,8 @@ export const MQTT_URL: string =
 export const MQTT_PROTOCOL: MqttProtocol =
 	process.env.MQTT_PROTOCOL === "mqtts" ? "mqtts" : "mqtt";
 export const MQTT_USERNAME: string = process.env.MQTT_USERNAME || "Test";
-export const MQTT_PASSWORD: string =
-	process.env.MQTT_PASSWORD || "test";
-export const MQTT_CLIENT_ID: string =
-	process.env.MQTT_CLIENT_ID || "test";
+export const MQTT_PASSWORD: string = process.env.MQTT_PASSWORD || "test";
+export const MQTT_CLIENT_ID: string = process.env.MQTT_CLIENT_ID || "test";
 export const MQTT_TOPIC: string = process.env.MQTT_TOPIC || "msh/#";
 
 export const PURGE_INTERVAL_SECONDS: number = Number.parseInt(
@@ -22,7 +20,7 @@ export const PURGE_ENVIROMENT_METRICS_AFTER_SECONDS: number = Number.parseInt(
 	process.env.PURGE_ENVIROMENT_METRICS_AFTER_SECONDS || "604800",
 );
 export const PURGE_POWER_METRICS_AFTER_SECONDS: number = Number.parseInt(
-	process.env.PURGE_POWER_METRICS_AFTER_SECONDS || "604800",
+	process.env.PURGE_POWER_METRICS_AFTER_SECONDS || "0",
 );
 export const PURGE_MAP_REPORTS_AFTER_SECONDS: number = Number.parseInt(
 	process.env.PURGE_MAP_REPORTS_AFTER_SECONDS || "604800",


### PR DESCRIPTION
## Summary
- disable automatic purging of power metrics by default so history is kept indefinitely
- add shared metric range helpers and extend the UI selectors with month/year/all history options
- guard time-range watchers and skip the time filter when requesting the full history

## Testing
- npm run check (app)
- npm run check (mqtt)


------
https://chatgpt.com/codex/tasks/task_e_68c8ae810d4c8323a14a8902a9010fea