### PR TITLE
Localize Meshtastic map UI with runtime language toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,136 +1,136 @@
-**Created by:** Liam Cottle\
-**Forked by:** Tilen Komel
+**Creato da:** [Liam Cottle](https://liamcottle.com)\
+**Fork di:** [Tilen Komel](https://github.com/KomelT)
 
-<h2 align="center">Meshtastic Map</h2>
+<h2 align="center">Mappa Meshtastic</h2>
 
-A map of all Meshtastic nodes heard via MQTT.
+Una mappa di tutti i nodi Meshtastic ricevuti tramite MQTT.
 
-My version of the map is available at https://map.meshnet.si
+La versione pubblica della mappa è disponibile all'indirizzo https://map.meshnet.si
 
-<img src="./screenshot.png">
+<img src="./screenshot.png" alt="Anteprima della Mappa Meshtastic">
 
-## How does it work?
+## Come funziona?
 
-- An [mqtt client](./src/mqtt.js) is persistently connected to `mqtt.meshnet.si` and subscribed to the `si/#` topic.
-- All messages received are attempted to be decoded as [ServiceEnvelope](https://buf.build/meshtastic/protobufs/docs/main:meshtastic#meshtastic.ServiceEnvelope) packets.
-- If a packet is encrypted, it attempts to decrypt it with the default `AQ==` key.
-- If a packet can't be decoded as a `ServiceEnvelope`, it is ignored.
-- `NODEINFO_APP` packets add a node to the database.
-- `POSITION_APP` packets update the position of a node in the database.
-- `NEIGHBORINFO_APP` packets log neighbours heard by a node to the database.
-- `TELEMETRY_APP` packets update battery and voltage metrics for a node in the database.
-- `TRACEROUTE_APP` packets log all trace routes performed by a node to the database.
-- `MAP_REPORT_APP` packets are stored in the database, but are not widely adopted, so are not used yet.
-- The database is a MySQL server, and a nodejs express server is running an API to serve data to the map interface.
+- Un [client MQTT](./mqtt/src/mqtt.ts) resta connesso a `mqtt.meshnet.si` e sottoscrive il topic `si/#`.
+- Tutti i messaggi ricevuti vengono decodificati come pacchetti [ServiceEnvelope](https://buf.build/meshtastic/protobufs/docs/main:meshtastic#meshtastic.ServiceEnvelope).
+- Se un pacchetto è cifrato, si tenta la decifratura con la chiave predefinita `AQ==`.
+- I pacchetti che non possono essere decodificati come `ServiceEnvelope` vengono ignorati.
+- I pacchetti `NODEINFO_APP` aggiungono un nodo al database.
+- I pacchetti `POSITION_APP` aggiornano la posizione del nodo nel database.
+- I pacchetti `NEIGHBORINFO_APP` registrano i vicini ascoltati da un nodo nel database.
+- I pacchetti `TELEMETRY_APP` aggiornano le metriche di batteria e tensione di un nodo nel database.
+- I pacchetti `TRACEROUTE_APP` memorizzano tutti i traceroute effettuati da un nodo nel database.
+- I pacchetti `MAP_REPORT_APP` vengono salvati nel database ma, poiché poco diffusi, non sono ancora utilizzati.
+- Il database è un server MySQL e un server Express Node.js espone un'API che fornisce i dati all'interfaccia della mappa.
 
-## Features
+## Funzionalità
 
-- [x] Connects to mqtt.meshtastic.org to collect nodes and metrics.
-- [x] Shows nodes on the map if they have reported a valid position.
-- [x] Search bar to find nodes by ID, Hex ID, Short Name and Long Name.
-- [x] Hover over nodes on the map to see basic information and a preview image.
-- [x] Click nodes on the map to show a sidebar with more info such as telemetry graphs and traceroutes.
-- [x] Ability to share a direct link to a node. The map will auto navigate to it.
-- [x] Device list. To see which hardware models are most popular.
-- [x] Mobile optimised layout.
-- [x] Settings available to hide nodes from the map if they haven't been updated in a while.
-- [x] Real-Time message UI to view `TEXT_MESSAGE_APP` packets as they come in.
-- [x] View position history of a node between a selectable time range.
-- [x] "Neighbours" map layer. Shows blue connection lines between nodes that heard the other node.
-  - This information is taken from the `NEIGHBORINFO_APP`.
-  - Some neighbour lines are clearly wrong.
-  - Meshtastic firmware older than [v2.3.2](https://github.com/meshtastic/firmware/releases/tag/v2.3.2.63df972) reports MQTT nodes as Neighbours.
-  - This was fixed in [meshtastic/firmware/#3457](https://github.com/meshtastic/firmware/pull/3457), but adoption will likely be slow...
+- [x] Connessione a mqtt.meshtastic.org per raccogliere nodi e metriche.
+- [x] Visualizzazione dei nodi sulla mappa quando inviano una posizione valida.
+- [x] Barra di ricerca per trovare nodi per ID, ID esadecimale, nome corto o nome lungo.
+- [x] Passa il mouse sui nodi per vedere informazioni di base e un'immagine di anteprima.
+- [x] Clicca sui nodi per aprire una barra laterale con altre informazioni, come grafici di telemetria e traceroute.
+- [x] Possibilità di condividere un link diretto a un nodo. La mappa si posizionerà automaticamente.
+- [x] Elenco dei dispositivi per vedere quali modelli hardware sono più diffusi.
+- [x] Layout ottimizzato per dispositivi mobili.
+- [x] Impostazioni per nascondere i nodi che non vengono aggiornati da tempo.
+- [x] Interfaccia in tempo reale per visualizzare i pacchetti `TEXT_MESSAGE_APP` non appena arrivano.
+- [x] Cronologia delle posizioni di un nodo con intervallo temporale selezionabile.
+- [x] Layer "Neighbours" che mostra linee di connessione blu tra nodi che si sono ascoltati a vicenda.
+  - Le informazioni provengono dai pacchetti `NEIGHBORINFO_APP`.
+  - Alcune linee possono risultare errate.
+  - Le versioni del firmware Meshtastic precedenti alla [v2.3.2](https://github.com/meshtastic/firmware/releases/tag/v2.3.2.63df972) riportano i nodi MQTT come vicini.
+  - Il problema è stato risolto in [meshtastic/firmware#3457](https://github.com/meshtastic/firmware/pull/3457), ma l'adozione potrebbe essere lenta.
 
-## Dev
+## Sviluppo
 
-Clone the project repo:
+Clona il repository:
 
 ```
-git clone https://github.com/KomelT/meshtastic-map
-cd meshtastic-map
+git clone https://github.com/meshtastic-map-ITA/meshtastic-map-ITA
+cd meshtastic-map-ITA
 ```
 
-Build Docker images:
+Compila le immagini Docker:
 
 ```
 docker compose -f docker-compose.dev.yaml build
 ```
 
-Update environment variables:
+Aggiorna le variabili d'ambiente:
 
 ```
 nano docker-compose.yaml
 ```
 
-ENV lists:
+Elenco variabili d'ambiente:
 
 - [MQTT](./mqtt/src/settings.ts)
 - [API](./api/src/settings.ts)
 - [APP](./app/index.js)
 
-Run:
+Avvia i servizi:
 
 ```
 docker compose -f docker-compose.dev.yaml up
 ```
 
-## Run
+## Esecuzione
 
-Clone the project repo:
+Clona il repository:
 
 ```
-git clone https://github.com/KomelT/meshtastic-map
-cd meshtastic-map
+git clone https://github.com/meshtastic-map-ITA/meshtastic-map-ITA
+cd meshtastic-map-ITA
 ```
 
-Build Docker images:
+Compila le immagini Docker:
 
 ```
 docker compose build
 ```
 
-Update environment variables:
+Aggiorna le variabili d'ambiente:
 
 ```
 nano docker-compose.yaml
 ```
 
-ENV lists:
+Elenco variabili d'ambiente:
 
 - [MQTT](./mqtt/src/settings.ts)
 - [API](./api/src/settings.ts)
 - [APP](./app/index.js)
 
-Run:
+Avvia i servizi:
 
 ```
 docker compose up
 ```
 
-## Updating
+## Aggiornamenti
 
-You can just `git pull` or pull new image from Docekr Hub. Migrations will handle DB update.
+È sufficiente eseguire `git pull` o scaricare l'immagine aggiornata da Docker Hub. Le migrazioni gestiranno automaticamente l'aggiornamento del database.
 
-## Testing
+## Test
 
-To execute unit tests, run the following;
+Per eseguire i test unitari:
 
 ```
 npm run test
 ```
 
-## Contributing
+## Contribuire
 
-If you have a feature request, or find a bug, please [open an issue](https://github.com/Komelt/meshtastic-map/issues) here on GitHub.
+Se vuoi proporre una nuova funzionalità o hai trovato un bug, [apri una issue](https://github.com/meshtastic-map-ITA/meshtastic-map-ITA/issues) su GitHub.
 
-## License
+## Licenza
 
 MIT
 
-## Legal
+## Note legali
 
-This project is not affiliated with or endorsed by the Meshtastic project.
-The Meshtastic logo is the trademark of Meshtastic LLC.
+Questo progetto non è affiliato né approvato dal progetto Meshtastic.
+Il logo Meshtastic è un marchio registrato di Meshtastic LLC.
 
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+IL SOFTWARE È FORNITO "COSÌ COM'È", SENZA ALCUN TIPO DI GARANZIA, ESPRESSA O IMPLICITA, INCLUSE MA NON LIMITATE ALLE GARANZIE DI COMMERCIABILITÀ, IDONEITÀ A UNO SCOPO SPECIFICO E NON VIOLAZIONE. IN NESSUN CASO GLI AUTORI O I TITOLARI DEL COPYRIGHT POTRANNO ESSERE RITENUTI RESPONSABILI PER QUALSIASI RECLAMO, DANNO O ALTRA RESPONSABILITÀ, SIA IN UN'AZIONE CONTRATTUALE, CIVILE O DI ALTRO TIPO, DERIVANTE DA, O CONNESSA A, IL SOFTWARE O L'USO O ALTRE OPERAZIONI NEL SOFTWARE.

--- a/api/package.json
+++ b/api/package.json
@@ -13,14 +13,14 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/liamcottle/meshtastic-map.git"
+		"url": "git+https://github.com/meshtastic-map-ITA/meshtastic-map-ITA.git"
 	},
 	"author": "",
 	"license": "ISC",
 	"bugs": {
-		"url": "https://github.com/liamcottle/meshtastic-map/issues"
+		"url": "https://github.com/meshtastic-map-ITA/meshtastic-map-ITA/issues"
 	},
-	"homepage": "https://github.com/liamcottle/meshtastic-map#readme",
+	"homepage": "https://github.com/meshtastic-map-ITA/meshtastic-map-ITA#readme",
 	"devDependencies": {
 		"@biomejs/biome": "1.9.2",
 		"@types/express": "^4.17.21",

--- a/app/public/assets/js/i18n.js
+++ b/app/public/assets/js/i18n.js
@@ -1,0 +1,481 @@
+(function () {
+        const LANGUAGE_STORAGE_KEY = "ui_language";
+        const DEFAULT_LANGUAGE = "it";
+
+        const LANGUAGE_OPTIONS = [
+                { code: "it", label: { it: "Italiano", en: "Italian" } },
+                { code: "en", label: { it: "Inglese", en: "English" } },
+        ];
+
+        const META_TRANSLATIONS = {
+                title: {
+                        it: "Mappa Meshtastic",
+                        en: "Meshtastic Map",
+                },
+                description: {
+                        it: "Una mappa interattiva dei nodi Meshtastic visibili sul server MQTT.",
+                        en: "An interactive map of all Meshtastic nodes.",
+                },
+        };
+
+        const TEXT_TRANSLATIONS = {
+                "Meshtastic Map": { it: "Mappa Meshtastic" },
+                "Service Announcement": { it: "Avviso di servizio" },
+                "Changes were made to mqtt.meshnet.si. Uplink your nodes to": {
+                        it: "Sono state apportate modifiche a mqtt.meshnet.si. Collega i tuoi nodi a",
+                },
+                "our MQTT server": { it: "il nostro server MQTT" },
+                "to continue showing on this map.": {
+                        it: "per continuare a visualizzarli su questa mappa.",
+                },
+                "Created by": { it: "Creato da" },
+                "Liam Cottle": { it: "Liam Cottle" },
+                "Forked by": { it: "Fork di" },
+                "Tilen Komel": { it: "Tilen Komel" },
+                "Only the first 500 results are shown.": {
+                        it: "Sono mostrati solo i primi 500 risultati.",
+                },
+                "No results found...": { it: "Nessun risultato trovato..." },
+                "Search {count} nodes...": { it: "Cerca tra {count} nodi..." },
+                "About": { it: "Informazioni" },
+                "Search": { it: "Cerca" },
+                "Devices": { it: "Dispositivi" },
+                "Random": { it: "Casuale" },
+                "Settings": { it: "Impostazioni" },
+                "Reload": { it: "Ricarica" },
+                "👋 Welcome to my open source map of Meshtastic nodes heard on the mqtt.meshnet.si MQTT server.": {
+                        it: "👋 Benvenuto nella mia mappa open source dei nodi Meshtastic rilevati sul server MQTT mqtt.meshnet.si.",
+                },
+                "Features": { it: "Funzionalità" },
+                "The map shows nodes that have sent a valid position to MQTT.": {
+                        it: "La mappa mostra i nodi che hanno inviato una posizione valida a MQTT.",
+                },
+                "Position packets must be unencrypted, or encrypted with the default key.": {
+                        it: "I pacchetti di posizione devono essere non crittografati oppure crittografati con la chiave predefinita.",
+                },
+                "Use the search bar to find nodes by ID or name.": {
+                        it: "Usa la barra di ricerca per trovare i nodi per ID o nome.",
+                },
+                "Hover over nodes (on desktop) to see basic details.": {
+                        it: "Passa il mouse sui nodi (su desktop) per vedere i dettagli di base.",
+                },
+                "Click a node to see info such as telemetry graphs and traceroutes.": {
+                        it: "Fai clic su un nodo per vedere informazioni come grafici di telemetria e traceroute.",
+                },
+                "Use the top right layers panel to show neighbours and waypoints.": {
+                        it: "Usa il pannello dei livelli in alto a destra per mostrare vicini e waypoint.",
+                },
+                "Use the settings button to configure the map to your liking.": {
+                        it: "Usa il pulsante Impostazioni per configurare la mappa secondo le tue preferenze.",
+                },
+                "Have a feature request, or found a bug?": {
+                        it: "Hai una richiesta di funzionalità o hai trovato un bug?",
+                },
+                "Open an issue": { it: "Apri una segnalazione" },
+                "on GitHub.": { it: "su GitHub." },
+                "FAQ": { it: "FAQ" },
+                "How do I add my node to the map?": {
+                        it: "Come aggiungo il mio nodo alla mappa?",
+                },
+                "Your node, or a node that hears your node must uplink to our MQTT server.": {
+                        it: "Il tuo nodo, o un nodo che lo riceve, deve effettuare l'uplink al nostro server MQTT.",
+                },
+                "Use the MQTT server details below to uplink to this map.": {
+                        it: "Utilizza i dettagli del server MQTT qui sotto per collegarti a questa mappa.",
+                },
+                "If your node has v2.5 firmware or newer, you must enable \"OK to MQTT\".": {
+                        it: "Se il tuo nodo ha il firmware v2.5 o successivo, devi abilitare \"OK to MQTT\".",
+                },
+                "What MQTT server should I use?": {
+                        it: "Quale server MQTT devo utilizzare?",
+                },
+                "Address: mqtt.meshnet.si": { it: "Indirizzo: mqtt.meshnet.si" },
+                "Username: slovenia": { it: "Nome utente: slovenia" },
+                "Password: meshnet-si-slovenia": { it: "Password: meshnet-si-slovenia" },
+                "Topic: si/meshnet/slovenia": { it: "Topic: si/meshnet/slovenia" },
+                "TLS Enabled: No / Yes": { it: "TLS abilitato: No / Sì" },
+                "How do I remove my node from the map?": {
+                        it: "Come rimuovo il mio nodo dalla mappa?",
+                },
+                "Nodes that have not been heard for 7 days are automatically removed.": {
+                        it: "I nodi che non vengono ascoltati per 7 giorni vengono rimossi automaticamente.",
+                },
+                "To have your node removed now, please": {
+                        it: "Per rimuovere subito il tuo nodo",
+                },
+                "contact me": { it: "contattami" },
+                "Disable position reporting in your node to prevent it coming back.": {
+                        it: "Disattiva l'invio della posizione nel tuo nodo per evitare che ricompaia.",
+                },
+                "Use custom encryption keys so the public can't see your position data.": {
+                        it: "Utilizza chiavi di crittografia personalizzate in modo che il pubblico non possa vedere i tuoi dati di posizione.",
+                },
+                "How do I see neighbours a node heard?": {
+                        it: "Come posso vedere i vicini ascoltati da un nodo?",
+                },
+                "Open the top right layers panel and enable neighbours.": {
+                        it: "Apri il pannello dei livelli in alto a destra e abilita i vicini.",
+                },
+                "Some neighbours are from MQTT, this is patched in latest firmware.": {
+                        it: "Alcuni vicini provengono da MQTT, questo è stato corretto nelle ultime versioni del firmware.",
+                },
+                "Legal": { it: "Note legali" },
+                "This project is not affiliated with or endorsed by the": {
+                        it: "Questo progetto non è affiliato né approvato dal",
+                },
+                "Meshtastic": { it: "Meshtastic" },
+                "project.": { it: "progetto." },
+                "The Meshtastic logo is the trademark of Meshtastic LLC.": {
+                        it: "Il logo Meshtastic è un marchio registrato di Meshtastic LLC.",
+                },
+                "Map tiles provided by": { it: "Tile della mappa fornite da" },
+                "OpenStreetMap": { it: "OpenStreetMap" },
+                "Dismiss": { it: "Chiudi" },
+                "Meshtastic Devices": { it: "Dispositivi Meshtastic" },
+                "Ordered by most popular": { it: "Ordinati per popolarità" },
+                "Node Info": { it: "Informazioni sul nodo" },
+                "This node has not reported a position.": {
+                        it: "Questo nodo non ha riportato alcuna posizione.",
+                },
+                "Sent Msgs": { it: "Messaggi inviati" },
+                "Received Msgs": { it: "Messaggi ricevuti" },
+                "Gated Msgs": { it: "Messaggi inoltrati" },
+                "Details": { it: "Dettagli" },
+                "ID": { it: "ID" },
+                "Hex ID": { it: "ID esadecimale" },
+                "Hex ID:": { it: "ID esadecimale:" },
+                "Role": { it: "Ruolo" },
+                "Hardware": { it: "Hardware" },
+                "Firmware": { it: "Firmware" },
+                "LoRa Config": { it: "Configurazione LoRa" },
+                "Region": { it: "Regione" },
+                "Modem Preset": { it: "Preset modem" },
+                "Has Default Channel": { it: "Ha il canale predefinito" },
+                "Position": { it: "Posizione" },
+                "Show History": { it: "Mostra storico" },
+                "Latitude, Longitude": { it: "Latitudine, Longitudine" },
+                "Lat/Long": { it: "Lat/Lon" },
+                "Altitude": { it: "Altitudine" },
+                "Device Metrics": { it: "Metriche del dispositivo" },
+                "1 Day": { it: "1 giorno" },
+                "3 Days": { it: "3 giorni" },
+                "7 Days": { it: "7 giorni" },
+                "Battery Level": { it: "Livello batteria" },
+                "Channel Utilization": { it: "Utilizzo del canale" },
+                "Air Util TX": { it: "Utilizzo TX aria" },
+                "Plugged In": { it: "Collegato all'alimentazione" },
+                "Voltage": { it: "Voltaggio" },
+                "Air Util Tx": { it: "Utilizzo TX aria" },
+                "Uptime": { it: "Tempo di attività" },
+                "Environment Metrics": { it: "Metriche ambientali" },
+                "Temperature": { it: "Temperatura" },
+                "Humidity": { it: "Umidità" },
+                "Pressure": { it: "Pressione" },
+                "Relative Humidity": { it: "Umidità relativa" },
+                "Barometric Pressure": { it: "Pressione barometrica" },
+                "Power Metrics": { it: "Metriche di alimentazione" },
+                "Channel 1": { it: "Canale 1" },
+                "Channel 2": { it: "Canale 2" },
+                "Channel 3": { it: "Canale 3" },
+                "MQTT": { it: "MQTT" },
+                "Topics this node sent packets to": { it: "Topic a cui questo nodo ha inviato pacchetti" },
+                "No packets seen on MQTT": { it: "Nessun pacchetto visto su MQTT" },
+                "Trace Routes": { it: "Traceroute" },
+                "Only 5 most recent are shown": { it: "Sono mostrati solo gli ultimi 5" },
+                "to": { it: "a" },
+                "No traceroutes seen on MQTT": { it: "Nessun traceroute visto su MQTT" },
+                "Other": { it: "Altro" },
+                "First Seen": { it: "Prima rilevazione" },
+                "Last Seen": { it: "Ultima rilevazione" },
+                "Neighbours Updated": { it: "Vicini aggiornati" },
+                "Position Updated": { it: "Posizione aggiornata" },
+                "Share Link": { it: "Condividi link" },
+                "Copy": { it: "Copia" },
+                "Short Name:": { it: "Nome breve:" },
+                "MQTT:": { it: "MQTT:" },
+                "Connected": { it: "Connesso" },
+                "Disconnected": { it: "Disconnesso" },
+                "Local Nodes Online:": { it: "Nodi locali online:" },
+                "Position Precision:": { it: "Precisione della posizione:" },
+                "Role:": { it: "Ruolo:" },
+                "Hardware:": { it: "Hardware:" },
+                "Firmware:": { it: "Firmware:" },
+                "LoRa Region:": { it: "Regione LoRa:" },
+                "Modem Preset:": { it: "Preset modem:" },
+                "Has Default Channel:": { it: "Ha il canale predefinito:" },
+                "Battery:": { it: "Batteria:" },
+                "Voltage:": { it: "Voltaggio:" },
+                "Ch Util:": { it: "Utilizzo canale:" },
+                "Air Util:": { it: "Utilizzo aria:" },
+                "Altitude:": { it: "Altitudine:" },
+                "Started the traceroute": { it: "Ha avviato il traceroute" },
+                "Forwarded the packet": { it: "Ha inoltrato il pacchetto" },
+                "Replied to traceroute": { it: "Ha risposto al traceroute" },
+                "Gated the packet to MQTT": { it: "Ha inoltrato il pacchetto su MQTT" },
+                "Raw Data": { it: "Dati grezzi" },
+                "Changes are only saved in this browser.": {
+                        it: "Le modifiche vengono salvate solo in questo browser.",
+                },
+                "Nodes Max Age": { it: "Anzianità massima dei nodi" },
+                "Nodes not updated within this time are hidden. Reload to update map.": {
+                        it: "I nodi non aggiornati entro questo intervallo vengono nascosti. Ricarica per aggiornare la mappa.",
+                },
+                "Show All": { it: "Mostra tutto" },
+                "15 minutes": { it: "15 minuti" },
+                "30 minutes": { it: "30 minuti" },
+                "1 hour": { it: "1 ora" },
+                "3 hours": { it: "3 ore" },
+                "6 hours": { it: "6 ore" },
+                "12 hours": { it: "12 ore" },
+                "24 hours": { it: "24 ore" },
+                "2 days": { it: "2 giorni" },
+                "3 days": { it: "3 giorni" },
+                "4 days": { it: "4 giorni" },
+                "5 days": { it: "5 giorni" },
+                "6 days": { it: "6 giorni" },
+                "7 days": { it: "7 giorni" },
+                "Nodes Disconnected Age": { it: "Tempo disconnessione nodi" },
+                "Nodes that have not uplinked to MQTT in this time will show as blue icons. Reload to update map.": {
+                        it: "I nodi che non hanno effettuato uplink a MQTT in questo intervallo vengono mostrati con icone blu. Ricarica per aggiornare la mappa.",
+                },
+                "45 minutes": { it: "45 minuti" },
+                "2 hours": { it: "2 ore" },
+                "Nodes Offline Age": { it: "Tempo offline nodi" },
+                "Nodes not updated within this time will show as red icons. Reload to update map.": {
+                        it: "I nodi non aggiornati entro questo intervallo vengono mostrati con icone rosse. Ricarica per aggiornare la mappa.",
+                },
+                "Don't show as offline": { it: "Non mostrare come offline" },
+                "Waypoints Max Age": { it: "Anzianità massima dei waypoint" },
+                "Waypoints not updated within this time are hidden. Reload to update map.": {
+                        it: "I waypoint non aggiornati entro questo intervallo vengono nascosti. Ricarica per aggiornare la mappa.",
+                },
+                "Neighbours Max Distance (meters)": { it: "Distanza massima vicini (metri)" },
+                "Neighbours further than this are hidden. Reload to update map.": {
+                        it: "I vicini oltre questa distanza vengono nascosti. Ricarica per aggiornare la mappa.",
+                },
+                "Zoom Level (go to node)": { it: "Livello di zoom (vai al nodo)" },
+                "How far to zoom map when navigating to a node.": {
+                        it: "Grado di zoom della mappa quando si naviga verso un nodo.",
+                },
+                "Temperature Format": { it: "Formato della temperatura" },
+                "Metrics will be shown in the selected format.": {
+                        it: "Le metriche verranno mostrate nel formato selezionato.",
+                },
+                "Celsius (ºC)": { it: "Celsius (ºC)" },
+                "Fahrenheit (ºF)": { it: "Fahrenheit (ºF)" },
+                "Auto Update Position in URL": { it: "Aggiornamento automatico posizione nell'URL" },
+                "Sets lat/lng/zoom as query parameters.": {
+                        it: "Imposta latitudine/longitudine/zoom come parametri della query.",
+                },
+                "Enable Map Animations": { it: "Abilita animazioni mappa" },
+                "Map will animate flying to nodes.": {
+                        it: "La mappa animerà il movimento verso i nodi.",
+                },
+                "1 Hour": { it: "1 ora" },
+                "24 Hours": { it: "24 ore" },
+                "From:": { it: "Da:" },
+                "To:": { it: "A:" },
+                "Language": { it: "Lingua" },
+                "Choose the interface language.": { it: "Scegli la lingua dell'interfaccia." },
+                "Yes": { it: "Sì" },
+                "No": { it: "No" },
+                "Neighbours Updated:": { it: "Vicini aggiornati:" },
+                "Position Updated:": { it: "Posizione aggiornata:" },
+                "Unnamed Node": { it: "Nodo senza nome" },
+                "Show Full Details": { it: "Mostra tutti i dettagli" },
+                "Show Neighbours (Heard Us)": { it: "Mostra vicini (ci hanno sentito)" },
+                "Show Neighbours (We Heard)": { it: "Mostra vicini (abbiamo sentito)" },
+                "Expires:": { it: "Scadenza:" },
+                "Lat/Lng:": { it: "Lat/Lon:" },
+                "From ID:": { it: "ID origine:" },
+                "From Hex ID:": { it: "ID esadecimale origine:" },
+                "From Node:": { it: "Dal nodo:" },
+                "From Node: ???": { it: "Dal nodo: ???" },
+                "ID:": { it: "ID:" },
+                "Updated:": { it: "Aggiornato:" },
+                "Legend": { it: "Legenda" },
+                "MQTT Connected": { it: "Connesso a MQTT" },
+                "MQTT Disconnected": { it: "MQTT disconnesso" },
+                "Offline Too Long": { it: "Offline da troppo tempo" },
+                "Nodes": { it: "Nodi" },
+                "Neighbours": { it: "Vicini" },
+                "Waypoints": { it: "Waypoint" },
+                "Position History": { it: "Storico posizioni" },
+                "Clipboard not supported. Site must be served via https on iOS.": {
+                        it: "Appunti non supportati. Il sito deve essere servito in HTTPS su iOS.",
+                },
+                "Link copied to clipboard!": { it: "Link copiato negli appunti!" },
+                "day": { it: "giorno" },
+                "days": { it: "giorni" },
+                "Tiles &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> | Data from <a target=\"_blank\" href=\"https://meshtastic.org/docs/software/integrations/mqtt/\">Meshtastic</a>": {
+                        it: "Tile &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> | Dati da <a target=\"_blank\" href=\"https://meshtastic.org/docs/software/integrations/mqtt/\">Meshtastic</a>",
+                },
+                "Tiles &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a>": {
+                        it: "Tile &copy; <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a>",
+                },
+                "Tiles &copy; <a href=\"https://developers.arcgis.com/documentation/mapping-apis-and-services/deployment/basemap-attribution/\">Esri</a> | Data from <a target=\"_blank\" href=\"https://meshtastic.org/docs/software/integrations/mqtt/\">Meshtastic</a>": {
+                        it: "Tile &copy; <a href=\"https://developers.arcgis.com/documentation/mapping-apis-and-services/deployment/basemap-attribution/\">Esri</a> | Dati da <a target=\"_blank\" href=\"https://meshtastic.org/docs/software/integrations/mqtt/\">Meshtastic</a>",
+                },
+                "Tiles &copy; Google | Data from <a target=\"_blank\" href=\"https://meshtastic.org/docs/software/integrations/mqtt/\">Meshtastic</a>": {
+                        it: "Tile &copy; Google | Dati da <a target=\"_blank\" href=\"https://meshtastic.org/docs/software/integrations/mqtt/\">Meshtastic</a>",
+                },
+                "Terrain images from <a href=\"http://www.heywhatsthat.com\" target=\"_blank\">HeyWhatsThat.com</a>": {
+                        it: "Immagini del terreno da <a href=\"http://www.heywhatsthat.com\" target=\"_blank\">HeyWhatsThat.com</a>",
+                },
+                "Could not find node:": { it: "Impossibile trovare il nodo:" },
+        };
+
+        const TEXT_NODE_CACHE = new WeakMap();
+
+        function getStoredLanguage() {
+                const stored = localStorage.getItem(LANGUAGE_STORAGE_KEY);
+                if (stored && LANGUAGE_OPTIONS.some((option) => option.code === stored)) {
+                        return stored;
+                }
+                const browser = navigator.language ? navigator.language.slice(0, 2) : null;
+                if (browser && LANGUAGE_OPTIONS.some((option) => option.code === browser)) {
+                        return browser;
+                }
+                return DEFAULT_LANGUAGE;
+        }
+
+        function getTranslationValue(original, language) {
+                const trimmed = original.trim();
+                const entry = TEXT_TRANSLATIONS[trimmed];
+                if (entry && entry[language]) {
+                        return original.replace(trimmed, entry[language]);
+                }
+                return original;
+        }
+
+        function formatTemplate(value, params) {
+                if (!params) {
+                        return value;
+                }
+                return value.replace(/\{(\w+)\}/g, (_, key) => {
+                        if (Object.prototype.hasOwnProperty.call(params, key)) {
+                                return params[key];
+                        }
+                        return "";
+                });
+        }
+
+        let isApplyingTranslations = false;
+
+        function applyTextTranslations(language) {
+                if (!document.body) {
+                        return;
+                }
+                isApplyingTranslations = true;
+                const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+                let node;
+                while ((node = walker.nextNode())) {
+                        const value = node.nodeValue;
+                        if (!value || !value.trim()) {
+                                continue;
+                        }
+                        if (!TEXT_NODE_CACHE.has(node)) {
+                                TEXT_NODE_CACHE.set(node, value);
+                        }
+                        const original = TEXT_NODE_CACHE.get(node);
+                        const translated = getTranslationValue(original, language);
+                        node.nodeValue = translated;
+                }
+                isApplyingTranslations = false;
+        }
+
+        let mutationObserver = null;
+
+        function ensureObserver() {
+                if (mutationObserver || !document.body) {
+                        return;
+                }
+                mutationObserver = new MutationObserver(() => {
+                        if (isApplyingTranslations) {
+                                return;
+                        }
+                        requestAnimationFrame(() => applyTextTranslations(currentLanguage));
+                });
+                mutationObserver.observe(document.body, { childList: true, subtree: true });
+        }
+
+        function applyMetaTranslations(language) {
+                document.title = META_TRANSLATIONS.title[language] || META_TRANSLATIONS.title.en;
+                const metaDescription = document.querySelector('meta[name="description"]');
+                if (metaDescription) {
+                        metaDescription.setAttribute(
+                                "content",
+                                META_TRANSLATIONS.description[language] || META_TRANSLATIONS.description.en,
+                        );
+                }
+                const ogTitle = document.querySelector('meta[property="og:title"]');
+                if (ogTitle) {
+                        ogTitle.setAttribute(
+                                "content",
+                                META_TRANSLATIONS.title[language] || META_TRANSLATIONS.title.en,
+                        );
+                }
+                const ogDescription = document.querySelector('meta[property="og:description"]');
+                if (ogDescription) {
+                        ogDescription.setAttribute(
+                                "content",
+                                META_TRANSLATIONS.description[language] || META_TRANSLATIONS.description.en,
+                        );
+                }
+        }
+
+        function applyLanguage(language) {
+                document.documentElement.setAttribute("lang", language);
+                applyMetaTranslations(language);
+                ensureObserver();
+                applyTextTranslations(language);
+        }
+
+        let currentLanguage = getStoredLanguage();
+
+        function setLanguage(language) {
+                currentLanguage = language;
+                localStorage.setItem(LANGUAGE_STORAGE_KEY, language);
+                applyLanguage(language);
+                window.dispatchEvent(
+                        new CustomEvent("i18n:language-changed", { detail: { language } }),
+                );
+        }
+
+        window.i18n = {
+                get language() {
+                        return currentLanguage;
+                },
+                setLanguage(language) {
+                        if (!LANGUAGE_OPTIONS.some((option) => option.code === language)) {
+                                return;
+                        }
+                        setLanguage(language);
+                },
+                refresh() {
+                        applyLanguage(currentLanguage);
+                },
+                translateString(english) {
+                        return TEXT_TRANSLATIONS[english]?.[currentLanguage] || english;
+                },
+                translateValue(english) {
+                        return getTranslationValue(english, currentLanguage);
+                },
+                translateTemplate(template, params) {
+                        const base = TEXT_TRANSLATIONS[template]?.[currentLanguage] || template;
+                        return formatTemplate(base, params);
+                },
+                getLanguageOptions() {
+                        return LANGUAGE_OPTIONS.map((option) => ({
+                                code: option.code,
+                                label: option.label[currentLanguage] || option.label.en,
+                        }));
+                },
+        };
+
+        if (document.readyState === "loading") {
+                document.addEventListener("DOMContentLoaded", () => applyLanguage(currentLanguage));
+        } else {
+                applyLanguage(currentLanguage);
+        }
+})();

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -55,12 +55,15 @@
 		<!-- axios -->
 		<script src="assets/js/axios@1.6.8/dist/axios.min.js"></script>
 
-		<!-- chart js -->
-		<script src="assets/js/chart.js@4.4.2/dist/chart.umd.js"></script>
-		<script src="assets/js/chartjs-adapter-moment/chartjs-adapter-moment.js"></script>
+                <!-- chart js -->
+                <script src="assets/js/chart.js@4.4.2/dist/chart.umd.js"></script>
+                <script src="assets/js/chartjs-adapter-moment/chartjs-adapter-moment.js"></script>
 
-		<!-- plausible -->
-		<script>
+                <!-- localisation -->
+                <script src="assets/js/i18n.js"></script>
+
+                <!-- plausible -->
+                <script>
 			(function () {
 			var ALLOWED_HOST = 'map.meshnet.si';
 			if (location.hostname === ALLOWED_HOST) {
@@ -265,11 +268,11 @@
 						<div
 							class="mx-3 flex-1 relative"
 							:class="{ 'hidden lg:block': !isShowingMobileSearch }">
-							<input
-								v-model="searchText"
-								type="text"
-								class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
-								:placeholder="`Search ${nodes.length} nodes...`" />
+                                                        <input
+                                                                v-model="searchText"
+                                                                type="text"
+                                                                class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                                                                :placeholder="searchPlaceholder" />
 							<div
 								v-if="searchText !== ''"
 								class="absolute z-search bg-white w-full border border-gray-200 rounded-lg shadow-md mt-1 overflow-y-scroll max-h-80 divide-y divide-gray-200">
@@ -577,7 +580,7 @@
 
 												<a
 													target="_blank"
-													href="https://github.com/KomelT/meshtastic-map"
+                                                                                                        href="https://github.com/meshtastic-map-ITA/meshtastic-map-ITA"
 													title="GitHub"
 													class="raise inline-flex items-center p-1.5 border border-transparent text-xs font-medium rounded-full shadow-sm text-white bg-[#333333] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#333333]">
 													<svg
@@ -697,7 +700,7 @@
 														<a
 															class="link"
 															target="_blank"
-															href="https://github.com/Komelt/meshtastic-map/issues"
+                                                                                                                        href="https://github.com/meshtastic-map-ITA/meshtastic-map-ITA/issues"
 															>Open an issue</a
 														>
 														on GitHub.
@@ -1247,9 +1250,12 @@
 													Has Default Channel
 												</div>
 												<div class="ml-auto text-sm text-gray-700">
-													<span v-if="selectedNode.has_default_channel != null"
-														>{{ selectedNode.has_default_channel ? "Yes" : "No"
-														}}</span
+                                                                                                        <span v-if="selectedNode.has_default_channel != null"
+                                                                                                                >{{
+                                                                                                                        selectedNode.has_default_channel
+                                                                                                                                ? translateText("Yes")
+                                                                                                                                : translateText("No")
+                                                                                                                }}</span
 													>
 													<span v-else>???</span>
 												</div>
@@ -2199,10 +2205,31 @@
 									</div>
 								</div>
 
-								<div class="overflow-y-auto divide-y divide-gray-200">
-									<!-- configNodesMaxAgeInSeconds -->
-									<div class="p-2">
-										<label class="block text-sm font-medium text-gray-900"
+                                                                <div class="overflow-y-auto divide-y divide-gray-200">
+                                                                        <!-- language selection -->
+                                                                        <div class="p-2">
+                                                                                <label class="block text-sm font-medium text-gray-900"
+                                                                                        >Language</label
+                                                                                >
+                                                                                <div class="text-xs text-gray-600 mb-2">
+                                                                                        Choose the interface language.
+                                                                                </div>
+                                                                                <select
+                                                                                        v-model="language"
+                                                                                        @change="onLanguageChange"
+                                                                                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                                                                        <option
+                                                                                                v-for="option in languageOptions"
+                                                                                                :key="option.code"
+                                                                                                :value="option.code">
+                                                                                                {{ option.label }}
+                                                                                        </option>
+                                                                                </select>
+                                                                        </div>
+
+                                                                        <!-- configNodesMaxAgeInSeconds -->
+                                                                        <div class="p-2">
+                                                                                <label class="block text-sm font-medium text-gray-900"
 											>Nodes Max Age</label
 										>
 										<div class="text-xs text-gray-600 mb-2">
@@ -2801,18 +2828,25 @@
 				return localStorage.setItem("config_zoom_level_go_to_node", value);
 			}
 
-			function isMobile() {
-				return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
-					navigator.userAgent
-				);
-			}
-		</script>
+                function isMobile() {
+                        return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+                                navigator.userAgent
+                        );
+                }
+
+                const translate = (english) => window.i18n.translateString(english);
+                const translateTemplate = (template, params) =>
+                        window.i18n.translateTemplate(template, params);
+                </script>
 
 		<script>
 			Vue.createApp({
-				data() {
-					return {
-						isShowingAnnouncement: this.shouldShowAnnouncement(),
+                                data() {
+                                        return {
+                                                language: window.i18n.language,
+                                                languageOptions: window.i18n.getLanguageOptions(),
+
+                                                isShowingAnnouncement: this.shouldShowAnnouncement(),
 
 						configNodesMaxAgeInSeconds: window.getConfigNodesMaxAgeInSeconds(),
 						configNodesDisconnectedAgeInSeconds:
@@ -2866,9 +2900,16 @@
 						moment: window.moment,
 					};
 				},
-				mounted: function () {
-					// load data
-					this.loadHardwareModelStats();
+                                mounted: function () {
+                                        window.i18n.refresh();
+                                        window.addEventListener(
+                                                "i18n:language-changed",
+                                                this.handleLanguageChangeEvent,
+                                        );
+                                        this.languageOptions = window.i18n.getLanguageOptions();
+
+                                        // load data
+                                        this.loadHardwareModelStats();
 
 					// handle map click callback from outside of vue
 					window._onMapClick = () => {
@@ -2900,12 +2941,37 @@
 					};
 
 					// handle nodes updated callback from outside of vue
-					window._onNodesUpdated = (nodes) => {
-						this.nodes = nodes;
-					};
-				},
-				methods: {
-					getAnnouncementId: function () {
+                                        window._onNodesUpdated = (nodes) => {
+                                                this.nodes = nodes;
+                                                window.i18n.refresh();
+                                        };
+                                },
+                                beforeUnmount: function () {
+                                        window.removeEventListener(
+                                                "i18n:language-changed",
+                                                this.handleLanguageChangeEvent,
+                                        );
+                                },
+                                methods: {
+                                        translateText: function (value) {
+                                                return translate(value);
+                                        },
+                                        translateTemplate: function (template, params) {
+                                                return translateTemplate(template, params);
+                                        },
+                                        onLanguageChange: function () {
+                                                window.i18n.setLanguage(this.language);
+                                                this.languageOptions = window.i18n.getLanguageOptions();
+                                        },
+                                        handleLanguageChangeEvent: function (event) {
+                                                const newLanguage = event?.detail?.language;
+                                                if (!newLanguage) {
+                                                        return;
+                                                }
+                                                this.language = newLanguage;
+                                                this.languageOptions = window.i18n.getLanguageOptions();
+                                        },
+                                        getAnnouncementId: function () {
 						// change this when making a new announcement
 						return "1";
 					},
@@ -3159,26 +3225,26 @@
 							data: {
 								labels: labels,
 								datasets: [
-									{
-										label: "Battery Level",
-										borderColor: "#3b82f6",
-										backgroundColor: "#3b82f6",
+                                                                        {
+                                                                                label: translate("Battery Level"),
+                                                                                borderColor: "#3b82f6",
+                                                                                backgroundColor: "#3b82f6",
 										pointStyle: false, // no points
 										fill: false,
 										data: batteryMetrics,
 									},
-									{
-										label: "Channel Util",
-										borderColor: "#22c55e",
-										backgroundColor: "#22c55e",
+                                                                        {
+                                                                                label: translate("Channel Utilization"),
+                                                                                borderColor: "#22c55e",
+                                                                                backgroundColor: "#22c55e",
 										showLine: false, // no lines between points
 										fill: false,
 										data: channelUtilizationMetrics,
 									},
-									{
-										label: "Air Util TX",
-										borderColor: "#f97316",
-										backgroundColor: "#f97316",
+                                                                        {
+                                                                                label: translate("Air Util TX"),
+                                                                                borderColor: "#f97316",
+                                                                                backgroundColor: "#f97316",
 										showLine: false, // no lines between points
 										fill: false,
 										data: airUtilTxMetrics,
@@ -3186,26 +3252,26 @@
 								],
 								labels: labels,
 								datasets: [
-									{
-										label: "Battery Level",
-										borderColor: "#3b82f6",
-										backgroundColor: "#3b82f6",
+                                                                        {
+                                                                                label: translate("Battery Level"),
+                                                                                borderColor: "#3b82f6",
+                                                                                backgroundColor: "#3b82f6",
 										pointStyle: false, // no points
 										fill: false,
 										data: batteryMetrics,
 									},
-									{
-										label: "Channel Util",
-										borderColor: "#22c55e",
-										backgroundColor: "#22c55e",
+                                                                        {
+                                                                                label: translate("Channel Utilization"),
+                                                                                borderColor: "#22c55e",
+                                                                                backgroundColor: "#22c55e",
 										showLine: false, // no lines between points
 										fill: false,
 										data: channelUtilizationMetrics,
 									},
-									{
-										label: "Air Util TX",
-										borderColor: "#f97316",
-										backgroundColor: "#f97316",
+                                                                        {
+                                                                                label: translate("Air Util TX"),
+                                                                                borderColor: "#f97316",
+                                                                                backgroundColor: "#f97316",
 										showLine: false, // no lines between points
 										fill: false,
 										data: airUtilTxMetrics,
@@ -3642,19 +3708,21 @@
 					},
 					copyShareLinkForNode: function (nodeId) {
 						// make sure copy to clipboard is supported
-						if (!navigator.clipboard || !navigator.clipboard.writeText) {
-							alert(
-								"Clipboard not supported. Site must be served via https on iOS."
-							);
-							return;
-						}
+                                                if (!navigator.clipboard || !navigator.clipboard.writeText) {
+                                                        alert(
+                                                                translate(
+                                                                        "Clipboard not supported. Site must be served via https on iOS."
+                                                                ),
+                                                        );
+                                                        return;
+                                                }
 
 						// copy share link to clipboard
 						const url = this.getShareLinkForNode(nodeId);
 						navigator.clipboard.writeText(url);
 
 						// tell use we copied it
-						alert("Link copied to clipboard!");
+                                                alert(translate("Link copied to clipboard!"));
 					},
 					dismissShowingNodeNeighbours: function () {
 						window._onHideNodeNeighboursClick();
@@ -3673,8 +3741,8 @@
 						var hours = Math.floor((secondsToFormat % (3600 * 24)) / 3600);
 						var minutes = Math.floor((secondsToFormat % 3600) / 60);
 						var seconds = Math.floor(secondsToFormat % 60);
-						var daysPlural = days === 1 ? "day" : "days";
-						return `${days} ${daysPlural} ${hours}h ${minutes}m ${seconds}s`;
+                                                var daysLabel = days === 1 ? translate("day") : translate("days");
+                                                return `${days} ${daysLabel} ${hours}h ${minutes}m ${seconds}s`;
 					},
 					formatTemperature: function (celsius) {
 						switch (this.configTemperatureFormat) {
@@ -3725,8 +3793,13 @@
 						return brightness > 0.5 ? "#000000" : "#FFFFFF";
 					},
 				},
-				computed: {
-					searchedNodes() {
+                                computed: {
+                                        searchPlaceholder() {
+                                                return translateTemplate("Search {count} nodes...", {
+                                                        count: this.nodes.length,
+                                                });
+                                        },
+                                        searchedNodes() {
 						// search nodes
 						const nodes = this.nodes.filter((node) => {
 							const matchesId = node.node_id
@@ -4081,7 +4154,7 @@
 				// find node
 				var node = findNodeById(id);
 				if (!node) {
-					alert("Could not find node: " + id);
+                                        alert(`${translate("Could not find node:")} ${id}`);
 					return false;
 				}
 
@@ -5117,142 +5190,126 @@
 				return `±${positionPrecisionInMeters}m`;
 			}
 
-			function getTooltipContentForNode(node) {
-				// determine if node was recently heard uplinking packets to mqtt
-				const nodeHasUplinkedToMqttRecently =
-					hasNodeUplinkedToMqttRecently(node);
-				var mqttStatus = `<span class="text-blue-700">Disconnected</span>`;
-				if (node.mqtt_connection_state_updated_at) {
-					var mqttStatusUpdatedAt = moment(
-						new Date(node.mqtt_connection_state_updated_at)
-					).fromNow();
-					if (nodeHasUplinkedToMqttRecently) {
-						mqttStatus = `<span><span class="text-green-700">Connected</span> (${mqttStatusUpdatedAt})</span>`;
-					} else {
-						mqttStatus = `<span><span class="text-blue-700">Disconnected</span> (${mqttStatusUpdatedAt})</span>`;
-					}
-				}
+                        function getTooltipContentForNode(node) {
+                                const nodeHasUplinkedToMqttRecently = hasNodeUplinkedToMqttRecently(node);
+                                let mqttStatus = `<span class="text-blue-700">${translate("Disconnected")}</span>`;
+                                if (node.mqtt_connection_state_updated_at) {
+                                        const mqttStatusUpdatedAt = moment(
+                                                new Date(node.mqtt_connection_state_updated_at)
+                                        ).fromNow();
+                                        if (nodeHasUplinkedToMqttRecently) {
+                                                mqttStatus = `<span><span class="text-green-700">${translate("Connected")}</span> (${mqttStatusUpdatedAt})</span>`;
+                                        } else {
+                                                mqttStatus = `<span><span class="text-blue-700">${translate("Disconnected")}</span> (${mqttStatusUpdatedAt})</span>`;
+                                        }
+                                }
 
-				var loraFrequencyRange = getRegionFrequencyRange(node.region_name);
+                                const loraFrequencyRange = getRegionFrequencyRange(node.region_name);
 
-				var tooltip =
-					`<img class="mb-4 w-40 mx-auto" src="/images/devices/${node.hardware_model_name}.png" onerror="this.classList.add('hidden')"/>` +
-					`<b>${escapeString(node.long_name)}</b>` +
-					`<br/>Short Name: ${escapeString(node.short_name)}` +
-					`<br/>MQTT: ${mqttStatus}` +
-					(node.num_online_local_nodes != null
-						? `<br/>Local Nodes Online: ${node.num_online_local_nodes}`
-						: "") +
-					(node.position_precision != null && node.position_precision !== 32
-						? `<br/>Position Precision: ${formatPositionPrecision(
-								node.position_precision
-						  )}`
-						: "") +
-					`<br/><br/>Role: ${node.role_name}` +
-					`<br/>Hardware: ${node.hardware_model_name}` +
-					(node.firmware_version != null
-						? `<br/>Firmware: ${node.firmware_version}`
-						: "") +
-					(node.region_name != null
-						? `<br/>LoRa Region: ${node.region_name} (${loraFrequencyRange})`
-						: "") +
-					(node.modem_preset_name != null
-						? `<br/>Modem Preset: ${node.modem_preset_name}`
-						: "") +
-					(node.has_default_channel != null
-						? `<br/>Has Default Channel: ${
-								node.has_default_channel ? "Yes" : "No"
-						  }`
-						: "");
+                                let tooltip =
+                                        `<img class="mb-4 w-40 mx-auto" src="/images/devices/${node.hardware_model_name}.png" onerror="this.classList.add('hidden')"/>` +
+                                        `<b>${escapeString(node.long_name)}</b>` +
+                                        `<br/>${translate("Short Name:")} ${escapeString(node.short_name)}` +
+                                        `<br/>${translate("MQTT:")} ${mqttStatus}` +
+                                        (node.num_online_local_nodes != null
+                                                ? `<br/>${translate("Local Nodes Online:")} ${node.num_online_local_nodes}`
+                                                : "") +
+                                        (node.position_precision != null && node.position_precision !== 32
+                                                ? `<br/>${translate("Position Precision:")} ${formatPositionPrecision(
+                                                                node.position_precision
+                                                  )}`
+                                                : "") +
+                                        `<br/><br/>${translate("Role:")} ${node.role_name}` +
+                                        `<br/>${translate("Hardware:")} ${node.hardware_model_name}` +
+                                        (node.firmware_version != null
+                                                ? `<br/>${translate("Firmware:")} ${node.firmware_version}`
+                                                : "") +
+                                        (node.region_name != null
+                                                ? `<br/>${translate("LoRa Region:")} ${node.region_name} (${loraFrequencyRange})`
+                                                : "") +
+                                        (node.modem_preset_name != null
+                                                ? `<br/>${translate("Modem Preset:")} ${node.modem_preset_name}`
+                                                : "") +
+                                        (node.has_default_channel != null
+                                                ? `<br/>${translate("Has Default Channel:")} ${
+                                                                node.has_default_channel ? translate("Yes") : translate("No")
+                                                        }`
+                                                : "");
 
-				if (node.battery_level) {
-					if (node.battery_level > 100) {
-						tooltip += `<br/>Battery: ${
-							node.battery_level > 100 ? "Plugged In" : node.battery_level
-						}`;
-					} else {
-						tooltip += `<br/>Battery: ${node.battery_level}%`;
-					}
-				}
+                                if (node.battery_level) {
+                                        if (node.battery_level > 100) {
+                                                tooltip += `<br/>${translate("Battery:")} ${translate("Plugged In")}`;
+                                        } else {
+                                                tooltip += `<br/>${translate("Battery:")} ${node.battery_level}%`;
+                                        }
+                                }
 
-				if (node.voltage) {
-					tooltip += `<br/>Voltage: ${Number(node.voltage).toFixed(2)}V`;
-				}
+                                if (node.voltage) {
+                                        tooltip += `<br/>${translate("Voltage:")} ${Number(node.voltage).toFixed(2)}V`;
+                                }
 
-				if (node.channel_utilization) {
-					tooltip += `<br/>Ch Util: ${Number(node.channel_utilization).toFixed(
-						2
-					)}%`;
-				}
+                                if (node.channel_utilization) {
+                                        tooltip += `<br/>${translate("Ch Util:")} ${Number(node.channel_utilization).toFixed(2)}%`;
+                                }
 
-				if (node.air_util_tx) {
-					tooltip += `<br/>Air Util: ${Number(node.air_util_tx).toFixed(2)}%`;
-				}
+                                if (node.air_util_tx) {
+                                        tooltip += `<br/>${translate("Air Util:")} ${Number(node.air_util_tx).toFixed(2)}%`;
+                                }
 
-				// ignore alt above 42949000 due to https://github.com/meshtastic/firmware/issues/3109
-				if (node.altitude && node.altitude < 42949000) {
-					tooltip += `<br/>Altitude: ${node.altitude}m`;
-				}
+                                if (node.altitude && node.altitude < 42949000) {
+                                        tooltip += `<br/>${translate("Altitude:")} ${node.altitude}m`;
+                                }
 
-				// bottom info
-				tooltip += `<br/><br/>ID: ${node.node_id}`;
-				tooltip += `<br/>Hex ID: ${node.node_id_hex}`;
-				tooltip += `<br/>Updated: ${moment(
-					new Date(node.updated_at)
-				).fromNow()}`;
-				tooltip += node.neighbours_updated_at
-					? `<br/>Neighbours Updated: ${moment(
-							new Date(node.neighbours_updated_at)
-					  ).fromNow()}`
-					: "";
-				tooltip += node.position_updated_at
-					? `<br/>Position Updated: ${moment(
-							new Date(node.position_updated_at)
-					  ).fromNow()}`
-					: "";
+                                tooltip += `<br/><br/>${translate("ID:")} ${node.node_id}`;
+                                tooltip += `<br/>${translate("Hex ID:")} ${node.node_id_hex}`;
+                                tooltip += `<br/>${translate("Updated:")} ${moment(new Date(node.updated_at)).fromNow()}`;
+                                tooltip += node.neighbours_updated_at
+                                        ? `<br/>${translate("Neighbours Updated:")} ${moment(
+                                                        new Date(node.neighbours_updated_at)
+                                          ).fromNow()}`
+                                        : "";
+                                tooltip += node.position_updated_at
+                                        ? `<br/>${translate("Position Updated:")} ${moment(
+                                                        new Date(node.position_updated_at)
+                                          ).fromNow()}`
+                                        : "";
 
-				// show details button
-				tooltip += `<br/><br/><button onclick="showNodeDetails(${node.node_id});" class="border border-gray-300 bg-gray-100 p-1 w-full rounded hover:bg-gray-200 mb-1">Show Full Details</button>`;
-				tooltip += `<br/><button onclick="showNodeNeighboursThatHeardUs(${node.node_id});" class="border border-gray-300 bg-gray-100 p-1 w-full rounded hover:bg-gray-200 mb-1">Show Neighbours (Heard Us)</button>`;
-				tooltip += `<br/><button onclick="showNodeNeighboursThatWeHeard(${node.node_id});" class="border border-gray-300 bg-gray-100 p-1 w-full rounded hover:bg-gray-200">Show Neighbours (We Heard)</button>`;
-				tooltip += `</div>`;
+                                tooltip += `<br/><br/><button onclick="showNodeDetails(${node.node_id});" class="border border-gray-300 bg-gray-100 p-1 w-full rounded hover:bg-gray-200 mb-1">${translate("Show Full Details")}</button>`;
+                                tooltip += `<br/><button onclick="showNodeNeighboursThatHeardUs(${node.node_id});" class="border border-gray-300 bg-gray-100 p-1 w-full rounded hover:bg-gray-200 mb-1">${translate("Show Neighbours (Heard Us)")}</button>`;
+                                tooltip += `<br/><button onclick="showNodeNeighboursThatWeHeard(${node.node_id});" class="border border-gray-300 bg-gray-100 p-1 w-full rounded hover:bg-gray-200">${translate("Show Neighbours (We Heard)")}</button>`;
+                                tooltip += `</div>`;
 
-				return tooltip;
-			}
+                                return tooltip;
+                        }
 
 			function getTooltipContentForWaypoint(waypoint) {
-				// get from node name
-				var fromNode = findNodeById(waypoint.from);
+                                const fromNode = findNodeById(waypoint.from);
 
-				var tooltip =
-					`<b>${escapeString(waypoint.name)}</b>` +
-					(waypoint.description
-						? `<br/>${escapeString(waypoint.description)}`
-						: "") +
-					`<br/><br/>Expires: ${moment(
-						new Date(waypoint.expire * 1000)
-					).fromNow()}` +
-					`<br/>Lat/Lng: ${waypoint.latitude}, ${waypoint.longitude}` +
-					`<br/><br/>From ID: ${waypoint.from}` +
-					`<br/>From Hex ID: !${Number(waypoint.from).toString(16)}`;
+                                let tooltip =
+                                        `<b>${escapeString(waypoint.name)}</b>` +
+                                        (waypoint.description
+                                                ? `<br/>${escapeString(waypoint.description)}`
+                                                : "") +
+                                        `<br/><br/>${translate("Expires:")} ${moment(
+                                                new Date(waypoint.expire * 1000)
+                                        ).fromNow()}` +
+                                        `<br/>${translate("Lat/Lng:")} ${waypoint.latitude}, ${waypoint.longitude}` +
+                                        `<br/><br/>${translate("From ID:")} ${waypoint.from}` +
+                                        `<br/>${translate("From Hex ID:")} !${Number(waypoint.from).toString(16)}`;
 
-				// show node name this waypoint is from, if possible
-				if (fromNode != null) {
-					tooltip += `<br/>From Node: <a href="#" onclick="goToNode(${
-						waypoint.from
-					})">${escapeString(fromNode.long_name) || "Unnamed Node"}</a>`;
-				} else {
-					tooltip += `<br/>From Node: ???`;
-				}
+                                if (fromNode != null) {
+                                        const nodeName = escapeString(fromNode.long_name) || translate("Unnamed Node");
+                                        tooltip += `<br/>${translate("From Node:")} <a href="#" onclick="goToNode(${waypoint.from})">${nodeName}</a>`;
+                                } else {
+                                        tooltip += `<br/>${translate("From Node: ???")}`;
+                                }
 
-				// bottom info
-				tooltip += `<br/><br/>ID: ${waypoint.waypoint_id}`;
-				tooltip += `<br/>Updated: ${moment(
-					new Date(waypoint.updated_at)
-				).fromNow()}`;
+                                tooltip += `<br/><br/>${translate("ID:")} ${waypoint.waypoint_id}`;
+                                tooltip += `<br/>${translate("Updated:")} ${moment(new Date(waypoint.updated_at)).fromNow()}`;
 
-				return tooltip;
-			}
+                                return tooltip;
+                        }
+
 
 			window._onHideNodeNeighboursClick = function () {
 				cleanUpNodeNeighbours();

--- a/donate.md
+++ b/donate.md
@@ -1,9 +1,9 @@
-# Donate
+# Donazioni
 
-Thank you for considering donating, this helps support my work on this project 😁
+Grazie per aver pensato a una donazione: ci aiuta a sostenere il lavoro su questo progetto 😁
 
-## How can I donate?
+## Come posso donare?
 
 - Bitcoin: 3FPBfiEwioWHFix3kZqe5bdU9F5o8mG8dh
 - Buy me a Coffee: [https://ko-fi.com/liamcottle](https://ko-fi.com/liamcottle)
-- Sponsor on GitHub: [https://github.com/sponsors/liamcottle](https://github.com/sponsors/liamcottle)
+- Sponsorizza su GitHub: [https://github.com/sponsors/liamcottle](https://github.com/sponsors/liamcottle)

--- a/mqtt/package.json
+++ b/mqtt/package.json
@@ -13,14 +13,14 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/liamcottle/meshtastic-map.git"
+		"url": "git+https://github.com/meshtastic-map-ITA/meshtastic-map-ITA.git"
 	},
 	"author": "",
 	"license": "ISC",
 	"bugs": {
-		"url": "https://github.com/liamcottle/meshtastic-map/issues"
+		"url": "https://github.com/meshtastic-map-ITA/meshtastic-map-ITA/issues"
 	},
-	"homepage": "https://github.com/liamcottle/meshtastic-map#readme",
+	"homepage": "https://github.com/meshtastic-map-ITA/meshtastic-map-ITA#readme",
 	"devDependencies": {
 		"@biomejs/biome": "1.9.2",
 		"@types/node": "^22.2.0",


### PR DESCRIPTION
## Summary
- add a standalone i18n helper that stores the selected UI language, updates meta tags, and maps interface strings to Italian and English translations
- wire the Vue app to use the translation helpers, including a language selector in the settings drawer and a localized search placeholder
- translate tooltip content, alerts, and other dynamic text so node details and share links honor the current language

## Testing
- npm run check (app)


------
https://chatgpt.com/codex/tasks/task_e_68c89d081c788323b802c494c53c0e65