### PR TITLE
Fix localization merge regression blocking web UI

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -2857,14 +2857,7 @@
                         window.i18n.translateTemplate(template, params);
                 </script>
 
-		<script>
-			Vue.createApp({
-                                data() {
-                                        return {
-                                                language: window.i18n.language,
-                                                languageOptions: window.i18n.getLanguageOptions(),
 
-                                                isShowingAnnouncement: this.shouldShowAnnouncement(),
                 <script>
                         const METRIC_TIME_RANGE_DAYS = {
                                 "1d": 1,
@@ -2880,9 +2873,12 @@
                         const MILLISECONDS_PER_DAY = 86400 * 1000;
 
                         Vue.createApp({
-				data() {
-					return {
-						isShowingAnnouncement: this.shouldShowAnnouncement(),
+                                data() {
+                                        return {
+                                                language: window.i18n.language,
+                                                languageOptions: window.i18n.getLanguageOptions(),
+
+                                                isShowingAnnouncement: this.shouldShowAnnouncement(),
 
 						configNodesMaxAgeInSeconds: window.getConfigNodesMaxAgeInSeconds(),
 						configNodesDisconnectedAgeInSeconds:


### PR DESCRIPTION
## Summary
- remove the duplicate `Vue.createApp` initialization that was left behind after the localization merge and prevented the UI from rendering
- ensure the Vue app initializes its localization state by defining the language and options in the single remaining app instance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c925d98ee4832384e282e79d5eea1c