### PR TITLE
Fix docker healthcheck configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -48,6 +48,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 6
+      start_period: 5s
       start_interval: 5s
 
   proxy:
@@ -68,6 +69,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 6
+      start_period: 5s
       start_interval: 5s
 
 volumes:


### PR DESCRIPTION
## Summary
- add missing `start_period` to database and proxy healthchecks to satisfy Docker compose requirements

## Testing
- not run (Docker CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68caa6e7ebd083238808026eb3e7997d