### PR TITLE
Add traceroute age configuration

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -2292,11 +2292,11 @@
 										</select>
 									</div>
 
-									<!-- configWaypointsMaxAgeInSeconds -->
-									<div class="p-2">
-										<label class="block text-sm font-medium text-gray-900"
-											>Età massima waypoint</label
-										>
+                                                                        <!-- configWaypointsMaxAgeInSeconds -->
+                                                                        <div class="p-2">
+                                                                                <label class="block text-sm font-medium text-gray-900"
+                                                                                        >Età massima waypoint</label
+                                                                                >
                                                                                 <div class="text-xs text-gray-600 mb-2">
                                                                                         I waypoint non aggiornati entro questo intervallo vengono nascosti. Ricarica
                                                                                         per aggiornare la mappa.
@@ -2318,13 +2318,42 @@
 											<option value="432000">5 giorni</option>
 											<option value="518400">6 giorni</option>
 											<option value="604800">7 giorni</option>
-										</select>
-									</div>
+                                                                                </select>
+                                                                        </div>
 
-									<!-- configNeighboursMaxDistanceInMeters -->
-									<div class="p-2">
-										<label class="block text-sm font-medium text-gray-900"
-											>Distanza massima vicini (metri)</label
+                                                                        <!-- configTraceroutesMaxAgeInSeconds -->
+                                                                        <div class="p-2">
+                                                                                <label class="block text-sm font-medium text-gray-900"
+                                                                                        >Età massima tracce</label
+                                                                                >
+                                                                                <div class="text-xs text-gray-600 mb-2">
+                                                                                        Le tracce vengono eliminate oltre questo intervallo. Ricarica per
+                                                                                        aggiornare la mappa.
+                                                                                </div>
+                                                                                <select
+                                                                                        v-model="configTraceroutesMaxAgeInSeconds"
+                                                                                        class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5">
+                                                                                        <option :value="null">Mostra tutto</option>
+                                                                                        <option value="900">15 minuti</option>
+                                                                                        <option value="1800">30 minuti</option>
+                                                                                        <option value="3600">1 ora</option>
+                                                                                        <option value="10800">3 ore</option>
+                                                                                        <option value="21600">6 ore</option>
+                                                                                        <option value="43200">12 ore</option>
+                                                                                        <option value="86400">24 ore</option>
+                                                                                        <option value="172800">2 giorni</option>
+                                                                                        <option value="259200">3 giorni</option>
+                                                                                        <option value="345600">4 giorni</option>
+                                                                                        <option value="432000">5 giorni</option>
+                                                                                        <option value="518400">6 giorni</option>
+                                                                                        <option value="604800">7 giorni</option>
+                                                                                </select>
+                                                                        </div>
+
+                                                                        <!-- configNeighboursMaxDistanceInMeters -->
+                                                                        <div class="p-2">
+                                                                                <label class="block text-sm font-medium text-gray-900"
+                                                                                        >Distanza massima vicini (metri)</label
 										>
                                                                                 <div class="text-xs text-gray-600 mb-2">
                                                                                         I vicini oltre questa distanza vengono nascosti. Ricarica per aggiornare la
@@ -2783,22 +2812,42 @@
 				return value != null ? parseInt(value) : null;
 			}
 
-			function setConfigWaypointsMaxAgeInSeconds(value) {
-				if (value != null) {
-					return localStorage.setItem(
-						"config_waypoints_max_age_in_seconds",
-						value
-					);
-				} else {
-					return localStorage.removeItem("config_waypoints_max_age_in_seconds");
-				}
-			}
+                        function setConfigWaypointsMaxAgeInSeconds(value) {
+                                if (value != null) {
+                                        return localStorage.setItem(
+                                                "config_waypoints_max_age_in_seconds",
+                                                value
+                                        );
+                                } else {
+                                        return localStorage.removeItem("config_waypoints_max_age_in_seconds");
+                                }
+                        }
 
-			function getConfigNeighboursMaxDistanceInMeters() {
-				const value = localStorage.getItem(
-					"config_neighbours_max_distance_in_meters"
-				);
-				return value != null ? parseInt(value) : null;
+                        function getConfigTraceroutesMaxAgeInSeconds() {
+                                const value = localStorage.getItem(
+                                        "config_traceroutes_max_age_in_seconds"
+                                );
+                                return value != null ? parseInt(value) : null;
+                        }
+
+                        function setConfigTraceroutesMaxAgeInSeconds(value) {
+                                if (value != null) {
+                                        return localStorage.setItem(
+                                                "config_traceroutes_max_age_in_seconds",
+                                                value
+                                        );
+                                } else {
+                                        return localStorage.removeItem(
+                                                "config_traceroutes_max_age_in_seconds"
+                                        );
+                                }
+                        }
+
+                        function getConfigNeighboursMaxDistanceInMeters() {
+                                const value = localStorage.getItem(
+                                        "config_neighbours_max_distance_in_meters"
+                                );
+                                return value != null ? parseInt(value) : null;
 			}
 
 			function setConfigNeighboursMaxDistanceInMeters(value) {
@@ -2834,12 +2883,14 @@
 						configNodesMaxAgeInSeconds: window.getConfigNodesMaxAgeInSeconds(),
 						configNodesDisconnectedAgeInSeconds:
 							window.getConfigNodesDisconnectedAgeInSeconds(),
-						configNodesOfflineAgeInSeconds:
-							window.getConfigNodesOfflineAgeInSeconds(),
-						configWaypointsMaxAgeInSeconds:
-							window.getConfigWaypointsMaxAgeInSeconds(),
-						configNeighboursMaxDistanceInMeters:
-							window.getConfigNeighboursMaxDistanceInMeters(),
+                                                configNodesOfflineAgeInSeconds:
+                                                        window.getConfigNodesOfflineAgeInSeconds(),
+                                                configWaypointsMaxAgeInSeconds:
+                                                        window.getConfigWaypointsMaxAgeInSeconds(),
+                                                configTraceroutesMaxAgeInSeconds:
+                                                        window.getConfigTraceroutesMaxAgeInSeconds(),
+                                                configNeighboursMaxDistanceInMeters:
+                                                        window.getConfigNeighboursMaxDistanceInMeters(),
 						configZoomLevelGoToNode: window.getConfigZoomLevelGoToNode(),
 						configAutoUpdatePositionInUrl:
 							window.getConfigAutoUpdatePositionInUrl(),
@@ -3812,16 +3863,22 @@
 							this.configNodesOfflineAgeInSeconds
 						);
 					},
-					configWaypointsMaxAgeInSeconds() {
-						window.setConfigWaypointsMaxAgeInSeconds(
-							this.configWaypointsMaxAgeInSeconds
-						);
-					},
-					configNeighboursMaxDistanceInMeters() {
-						window.setConfigNeighboursMaxDistanceInMeters(
-							this.configNeighboursMaxDistanceInMeters
-						);
-					},
+                                        configWaypointsMaxAgeInSeconds() {
+                                                window.setConfigWaypointsMaxAgeInSeconds(
+                                                        this.configWaypointsMaxAgeInSeconds
+                                                );
+                                        },
+                                        configTraceroutesMaxAgeInSeconds() {
+                                                window.setConfigTraceroutesMaxAgeInSeconds(
+                                                        this.configTraceroutesMaxAgeInSeconds
+                                                );
+                                                renderTraceroutes();
+                                        },
+                                        configNeighboursMaxDistanceInMeters() {
+                                                window.setConfigNeighboursMaxDistanceInMeters(
+                                                        this.configNeighboursMaxDistanceInMeters
+                                                );
+                                        },
 					configZoomLevelGoToNode() {
 						window.setConfigZoomLevelGoToNode(this.configZoomLevelGoToNode);
 					},
@@ -4608,7 +4665,32 @@
                                         return;
                                 }
 
-                                for (const traceroute of traceroutes) {
+                                let traceroutesToRender = traceroutes;
+                                const configTraceroutesMaxAgeInSeconds =
+                                        getConfigTraceroutesMaxAgeInSeconds();
+                                if (configTraceroutesMaxAgeInSeconds) {
+                                        const now = moment();
+                                        traceroutesToRender = traceroutes.filter((traceroute) => {
+                                                const updatedAt = traceroute?.updated_at ?? traceroute?.created_at;
+                                                if (!updatedAt) {
+                                                        return true;
+                                                }
+
+                                                const updatedAtMoment = moment(updatedAt);
+                                                if (!updatedAtMoment.isValid()) {
+                                                        return true;
+                                                }
+
+                                                const ageInMillis = now.diff(updatedAtMoment);
+                                                return ageInMillis <= configTraceroutesMaxAgeInSeconds * 1000;
+                                        });
+                                }
+
+                                if (!Array.isArray(traceroutesToRender) || traceroutesToRender.length === 0) {
+                                        return;
+                                }
+
+                                for (const traceroute of traceroutesToRender) {
                                         const pathNodeIds = [];
 
                                         if (traceroute?.to != null) {

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -2970,13 +2970,16 @@
 						selectedNode: null,
 						selectedNodeDeviceMetrics: [],
 						selectedNodeEnvironmentMetrics: [],
-						selectedNodePowerMetrics: [],
-						selectedNodeMqttMetrics: [],
-						selectedNodeTraceroutes: [],
+                                                selectedNodePowerMetrics: [],
+                                                selectedNodeMqttMetrics: [],
+                                                selectedNodeTraceroutes: [],
 
-						deviceMetricsTimeRange: "3d",
-						environmentMetricsTimeRange: "3d",
-						powerMetricsTimeRange: "3d",
+                                                tracerouteAgeTicker: 0,
+                                                tracerouteAgeIntervalId: null,
+
+                                                deviceMetricsTimeRange: "3d",
+                                                environmentMetricsTimeRange: "3d",
+                                                powerMetricsTimeRange: "3d",
 
 						isPositionHistoryModalExpanded: true,
 						positionHistoryDateTimeFrom: null,
@@ -3027,15 +3030,21 @@
 						this.selectedNodeToShowNeighboursType = "heard_us";
 					};
 
-					// handle nodes updated callback from outside of vue
-					window._onNodesUpdated = (nodes) => {
-						this.nodes = nodes;
-					};
-				},
-				methods: {
-					getAnnouncementId: function () {
-						// change this when making a new announcement
-						return "1";
+                                        // handle nodes updated callback from outside of vue
+                                        window._onNodesUpdated = (nodes) => {
+                                                this.nodes = nodes;
+                                        };
+
+                                        this.tracerouteAgeIntervalId = window.setInterval(() => {
+                                                this.tracerouteAgeTicker =
+                                                        (this.tracerouteAgeTicker + 1) % Number.MAX_SAFE_INTEGER;
+                                                renderTraceroutes();
+                                        }, 30 * 1000);
+                                },
+                                methods: {
+                                        getAnnouncementId: function () {
+                                                // change this when making a new announcement
+                                                return "1";
 					},
 					shouldShowAnnouncement: function () {
 						const lastSeenAnnouncementId = window.localStorage.getItem(
@@ -3907,14 +3916,17 @@
                                                 return latestPowerMetric;
                                         },
                                         filteredSelectedNodeTraceroutes() {
+                                                // include tracerouteAgeTicker so vue recomputes the filtered list as time passes
+                                                void this.tracerouteAgeTicker;
+
                                                 return filterTraceroutesByMaxAge(
                                                         this.selectedNodeTraceroutes,
                                                         this.configTraceroutesMaxAgeInSeconds,
                                                         this.moment
                                                 );
                                         },
-				},
-				watch: {
+                                },
+                                watch: {
 					configNodesMaxAgeInSeconds() {
 						window.setConfigNodesMaxAgeInSeconds(
 							this.configNodesMaxAgeInSeconds
@@ -3975,9 +3987,15 @@
                                                         this.loadNodePowerMetrics(this.selectedNode.node_id);
                                                 }
                                         },
-				},
-			}).mount("#app");
-		</script>
+                                },
+                                unmounted() {
+                                        if (this.tracerouteAgeIntervalId != null) {
+                                                window.clearInterval(this.tracerouteAgeIntervalId);
+                                                this.tracerouteAgeIntervalId = null;
+                                        }
+                                },
+                        }).mount("#app");
+                </script>
 
 		<script>
                         // global state

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -1740,21 +1740,46 @@
 									</div>
 
 									<!-- traceroutes -->
-									<div>
-										<div class="bg-gray-200 p-2">
-											<div class="font-semibold">Traceroute</div>
-											<div class="text-sm text-gray-600">
-												Sono mostrati solo i 5 più recenti
-											</div>
-										</div>
-										<ul role="list" class="flex-1 divide-y divide-gray-200">
-											<template v-if="selectedNodeTraceroutes.length > 0">
-												<li
-													@click="showTraceRoute(traceroute)"
-													v-for="traceroute of selectedNodeTraceroutes">
-													<div class="relative flex items-center">
-														<div class="block flex-1 px-4 py-2">
-															<div
+                                                                        <div>
+                                                                                <div class="bg-gray-200 p-2">
+                                                                                        <div class="font-semibold">Traceroute</div>
+                                                                                        <div class="text-sm text-gray-600">
+                                                                                                Sono mostrati solo i 5 più recenti che rispettano l'età massima configurata.
+                                                                                        </div>
+                                                                                </div>
+                                                                                <div class="p-2 space-y-1 border-b border-gray-200">
+                                                                                        <label class="block text-xs font-medium text-gray-700"
+                                                                                                >Età massima tracce</label
+                                                                                        >
+                                                                                        <select
+                                                                                                v-model="configTraceroutesMaxAgeInSeconds"
+                                                                                                class="bg-gray-50 border border-gray-300 text-gray-900 text-xs rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-1.5"
+                                                                                        >
+                                                                                                <option :value="null">Mostra tutto</option>
+                                                                                                <option value="900">15 minuti</option>
+                                                                                                <option value="1800">30 minuti</option>
+                                                                                                <option value="3600">1 ora</option>
+                                                                                                <option value="10800">3 ore</option>
+                                                                                                <option value="21600">6 ore</option>
+                                                                                                <option value="43200">12 ore</option>
+                                                                                                <option value="86400">24 ore</option>
+                                                                                                <option value="172800">2 giorni</option>
+                                                                                                <option value="259200">3 giorni</option>
+                                                                                                <option value="345600">4 giorni</option>
+                                                                                                <option value="432000">5 giorni</option>
+                                                                                                <option value="518400">6 giorni</option>
+                                                                                                <option value="604800">7 giorni</option>
+                                                                                        </select>
+                                                                                </div>
+                                                                                <ul role="list" class="flex-1 divide-y divide-gray-200">
+                                                                                        <template v-if="filteredSelectedNodeTraceroutes.length > 0">
+                                                                                                <li
+                                                                                                        @click="showTraceRoute(traceroute)"
+                                                                                                        v-for="traceroute of filteredSelectedNodeTraceroutes"
+                                                                                                        :key="`traceroute-${traceroute.id}`">
+                                                                                                        <div class="relative flex items-center">
+                                                                                                                <div class="block flex-1 px-4 py-2">
+                                                                                                                        <div
 																class="relative flex min-w-0 flex-1 items-center">
 																<div>
 																	<p class="text-sm text-gray-900">
@@ -1782,18 +1807,18 @@
 													</div>
 												</li>
 											</template>
-											<template v-else>
-												<li>
-													<div class="relative flex items-center">
-														<div class="block flex-1 px-4 py-2">
-															<div
-																class="relative flex min-w-0 flex-1 items-center">
-																<div class="truncate">
-																	<div class="text-sm text-gray-700">
-																		Nessun traceroute visto su MQTT
-																	</div>
-																</div>
-															</div>
+                                                                                        <template v-else>
+                                                                                                <li>
+                                                                                                        <div class="relative flex items-center">
+                                                                                                                <div class="block flex-1 px-4 py-2">
+                                                                                                                        <div
+                                                                                                                                class="relative flex min-w-0 flex-1 items-center">
+                                                                                                                                <div class="truncate">
+                                                                                                                                        <div class="text-sm text-gray-700">
+                                                                                                                                                Nessun traceroute recente visto su MQTT
+                                                                                                                                       </div>
+                                                                                                                                </div>
+                                                                                                                        </div>
 														</div>
 													</div>
 												</li>
@@ -2843,6 +2868,41 @@
                                 }
                         }
 
+                        function filterTraceroutesByMaxAge(
+                                traceroutes,
+                                maxAgeInSeconds,
+                                momentLib
+                        ) {
+                                if (!Array.isArray(traceroutes) || traceroutes.length === 0) {
+                                        return [];
+                                }
+
+                                if (
+                                        maxAgeInSeconds == null ||
+                                        Number.isNaN(Number(maxAgeInSeconds))
+                                ) {
+                                        return traceroutes;
+                                }
+
+                                const momentToUse = momentLib ?? moment;
+                                const now = momentToUse();
+
+                                return traceroutes.filter((traceroute) => {
+                                        const updatedAt = traceroute?.updated_at ?? traceroute?.created_at;
+                                        if (!updatedAt) {
+                                                return true;
+                                        }
+
+                                        const updatedAtMoment = momentToUse(updatedAt);
+                                        if (!updatedAtMoment?.isValid?.()) {
+                                                return true;
+                                        }
+
+                                        const ageInMillis = now.diff(updatedAtMoment);
+                                        return ageInMillis <= maxAgeInSeconds * 1000;
+                                });
+                        }
+
                         function getConfigNeighboursMaxDistanceInMeters() {
                                 const value = localStorage.getItem(
                                         "config_neighbours_max_distance_in_meters"
@@ -3842,10 +3902,17 @@
 						// only return the first 500 results to avoid ui lag...
 						return nodes.slice(0, 500);
 					},
-					selectedNodeLatestPowerMetric() {
-						const [latestPowerMetric] = this.selectedNodePowerMetrics.slice(-1);
-						return latestPowerMetric;
-					},
+                                        selectedNodeLatestPowerMetric() {
+                                                const [latestPowerMetric] = this.selectedNodePowerMetrics.slice(-1);
+                                                return latestPowerMetric;
+                                        },
+                                        filteredSelectedNodeTraceroutes() {
+                                                return filterTraceroutesByMaxAge(
+                                                        this.selectedNodeTraceroutes,
+                                                        this.configTraceroutesMaxAgeInSeconds,
+                                                        this.moment
+                                                );
+                                        },
 				},
 				watch: {
 					configNodesMaxAgeInSeconds() {
@@ -4665,26 +4732,11 @@
                                         return;
                                 }
 
-                                let traceroutesToRender = traceroutes;
-                                const configTraceroutesMaxAgeInSeconds =
-                                        getConfigTraceroutesMaxAgeInSeconds();
-                                if (configTraceroutesMaxAgeInSeconds) {
-                                        const now = moment();
-                                        traceroutesToRender = traceroutes.filter((traceroute) => {
-                                                const updatedAt = traceroute?.updated_at ?? traceroute?.created_at;
-                                                if (!updatedAt) {
-                                                        return true;
-                                                }
-
-                                                const updatedAtMoment = moment(updatedAt);
-                                                if (!updatedAtMoment.isValid()) {
-                                                        return true;
-                                                }
-
-                                                const ageInMillis = now.diff(updatedAtMoment);
-                                                return ageInMillis <= configTraceroutesMaxAgeInSeconds * 1000;
-                                        });
-                                }
+                                const traceroutesToRender = filterTraceroutesByMaxAge(
+                                        traceroutes,
+                                        getConfigTraceroutesMaxAgeInSeconds(),
+                                        moment
+                                );
 
                                 if (!Array.isArray(traceroutesToRender) || traceroutesToRender.length === 0) {
                                         return;


### PR DESCRIPTION
## Summary
- add a settings control that lets users choose the maximum age for displayed traceroute tracks
- persist the traceroute age preference and re-render traceroutes whenever it changes
- filter rendered traceroutes on the map based on the configured age to automatically clear old tracks

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cb43fa7a548323a3f16769b8cf04e8