### PR TITLE
Expose traceroute age limit in header

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -394,39 +394,62 @@
                                                                         <span class="tooltip-text">Dispositivi</span>
 								</div>
 							</a>
-							<a
-								href="#"
-								class="tooltip rounded-full hidden lg:block"
-								onclick="goToRandomNode()">
-								<div
-									id="random-button"
-									class="bg-gray-100 hover:bg-gray-200 p-2 rounded-full">
-									<svg
-										class="w-6 h-6"
-										xmlns="http://www.w3.org/2000/svg"
-										viewBox="0 0 24 24"
-										stroke-width="1.5"
-										stroke="currentColor"
-										fill="none"
-										stroke-linecap="round"
-										stroke-linejoin="round">
-										<path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-										<path d="M18 4l3 3l-3 3"></path>
-										<path d="M18 20l3 -3l-3 -3"></path>
-										<path d="M3 7h3a5 5 0 0 1 5 5a5 5 0 0 0 5 5h5"></path>
-										<path
-											d="M21 7h-5a4.978 4.978 0 0 0 -3 1m-4 8a4.984 4.984 0 0 1 -3 1h-3"></path>
-									</svg>
-								</div>
-								<div class="hidden sm:block">
+                                                        <a
+                                                                href="#"
+                                                                class="tooltip rounded-full hidden lg:block"
+                                                                onclick="goToRandomNode()">
+                                                                <div
+                                                                        id="random-button"
+                                                                        class="bg-gray-100 hover:bg-gray-200 p-2 rounded-full">
+                                                                        <svg
+                                                                                class="w-6 h-6"
+                                                                                xmlns="http://www.w3.org/2000/svg"
+                                                                                viewBox="0 0 24 24"
+                                                                                stroke-width="1.5"
+                                                                                stroke="currentColor"
+                                                                                fill="none"
+                                                                                stroke-linecap="round"
+                                                                                stroke-linejoin="round">
+                                                                                <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+                                                                                <path d="M18 4l3 3l-3 3"></path>
+                                                                                <path d="M18 20l3 -3l-3 -3"></path>
+                                                                                <path d="M3 7h3a5 5 0 0 1 5 5a5 5 0 0 0 5 5h5"></path>
+                                                                                <path
+                                                                                        d="M21 7h-5a4.978 4.978 0 0 0 -3 1m-4 8a4.984 4.984 0 0 1 -3 1h-3"></path>
+                                                                        </svg>
+                                                                </div>
+                                                                <div class="hidden sm:block">
                                                                         <span class="tooltip-text">Casuale</span>
-								</div>
-							</a>
-							<a
-								@click="isShowingSettings = true"
-								href="javascript:void(0)"
-								class="tooltip rounded-full">
-								<div class="bg-gray-100 hover:bg-gray-200 p-2 rounded-full">
+                                                                </div>
+                                                        </a>
+                                                        <div
+                                                                class="hidden md:flex items-center space-x-1 bg-white/80 border border-gray-200 rounded-full px-2 py-1 text-xs text-gray-700 shadow-sm"
+                                                        >
+                                                                <label
+                                                                        for="header-traceroute-age"
+                                                                        class="font-medium whitespace-nowrap"
+                                                                >
+                                                                        Età tracce
+                                                                </label>
+                                                                <select
+                                                                        id="header-traceroute-age"
+                                                                        v-model="configTraceroutesMaxAgeInSeconds"
+                                                                        class="bg-white border border-gray-300 text-gray-900 text-xs rounded-md focus:ring-blue-500 focus:border-blue-500 py-0.5 pl-2 pr-6"
+                                                                >
+                                                                        <option
+                                                                                v-for="option in tracerouteAgeOptions"
+                                                                                :key="`header-traceroute-age-${option.value === null ? 'all' : option.value}`"
+                                                                                :value="option.value"
+                                                                        >
+                                                                                {{ option.label }}
+                                                                        </option>
+                                                                </select>
+                                                        </div>
+                                                        <a
+                                                                @click="isShowingSettings = true"
+                                                                href="javascript:void(0)"
+                                                                class="tooltip rounded-full">
+                                                                <div class="bg-gray-100 hover:bg-gray-200 p-2 rounded-full">
 									<svg
 										class="w-6 h-6"
 										xmlns="http://www.w3.org/2000/svg"
@@ -1740,21 +1763,39 @@
 									</div>
 
 									<!-- traceroutes -->
-									<div>
-										<div class="bg-gray-200 p-2">
-											<div class="font-semibold">Traceroute</div>
-											<div class="text-sm text-gray-600">
-												Sono mostrati solo i 5 più recenti
-											</div>
-										</div>
-										<ul role="list" class="flex-1 divide-y divide-gray-200">
-											<template v-if="selectedNodeTraceroutes.length > 0">
-												<li
-													@click="showTraceRoute(traceroute)"
-													v-for="traceroute of selectedNodeTraceroutes">
-													<div class="relative flex items-center">
-														<div class="block flex-1 px-4 py-2">
-															<div
+                                                                        <div>
+                                                                                <div class="bg-gray-200 p-2">
+                                                                                        <div class="font-semibold">Traceroute</div>
+                                                                                        <div class="text-sm text-gray-600">
+                                                                                                Sono mostrati solo i 5 più recenti che rispettano l'età massima configurata.
+                                                                                        </div>
+                                                                                </div>
+                                                                                <div class="p-2 space-y-1 border-b border-gray-200">
+                                                                                        <label class="block text-xs font-medium text-gray-700"
+                                                                                                >Età massima tracce</label
+                                                                                        >
+                                                                                        <select
+                                                                                                v-model="configTraceroutesMaxAgeInSeconds"
+                                                                                                class="bg-gray-50 border border-gray-300 text-gray-900 text-xs rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-1.5"
+                                                                                        >
+                                                                                                <option
+                                                                                                        v-for="option in tracerouteAgeOptions"
+                                                                                                        :key="`node-traceroute-age-${option.value === null ? 'all' : option.value}`"
+                                                                                                        :value="option.value"
+                                                                                                >
+                                                                                                        {{ option.label }}
+                                                                                                </option>
+                                                                                        </select>
+                                                                               </div>
+                                                                                <ul role="list" class="flex-1 divide-y divide-gray-200">
+                                                                                        <template v-if="filteredSelectedNodeTraceroutes.length > 0">
+                                                                                                <li
+                                                                                                        @click="showTraceRoute(traceroute)"
+                                                                                                        v-for="traceroute of filteredSelectedNodeTraceroutes"
+                                                                                                        :key="`traceroute-${traceroute.id}`">
+                                                                                                        <div class="relative flex items-center">
+                                                                                                                <div class="block flex-1 px-4 py-2">
+                                                                                                                        <div
 																class="relative flex min-w-0 flex-1 items-center">
 																<div>
 																	<p class="text-sm text-gray-900">
@@ -1782,18 +1823,18 @@
 													</div>
 												</li>
 											</template>
-											<template v-else>
-												<li>
-													<div class="relative flex items-center">
-														<div class="block flex-1 px-4 py-2">
-															<div
-																class="relative flex min-w-0 flex-1 items-center">
-																<div class="truncate">
-																	<div class="text-sm text-gray-700">
-																		Nessun traceroute visto su MQTT
-																	</div>
-																</div>
-															</div>
+                                                                                        <template v-else>
+                                                                                                <li>
+                                                                                                        <div class="relative flex items-center">
+                                                                                                                <div class="block flex-1 px-4 py-2">
+                                                                                                                        <div
+                                                                                                                                class="relative flex min-w-0 flex-1 items-center">
+                                                                                                                                <div class="truncate">
+                                                                                                                                        <div class="text-sm text-gray-700">
+                                                                                                                                                Nessun traceroute recente visto su MQTT
+                                                                                                                                       </div>
+                                                                                                                                </div>
+                                                                                                                        </div>
 														</div>
 													</div>
 												</li>
@@ -2292,11 +2333,11 @@
 										</select>
 									</div>
 
-									<!-- configWaypointsMaxAgeInSeconds -->
-									<div class="p-2">
-										<label class="block text-sm font-medium text-gray-900"
-											>Età massima waypoint</label
-										>
+                                                                        <!-- configWaypointsMaxAgeInSeconds -->
+                                                                        <div class="p-2">
+                                                                                <label class="block text-sm font-medium text-gray-900"
+                                                                                        >Età massima waypoint</label
+                                                                                >
                                                                                 <div class="text-xs text-gray-600 mb-2">
                                                                                         I waypoint non aggiornati entro questo intervallo vengono nascosti. Ricarica
                                                                                         per aggiornare la mappa.
@@ -2318,13 +2359,36 @@
 											<option value="432000">5 giorni</option>
 											<option value="518400">6 giorni</option>
 											<option value="604800">7 giorni</option>
-										</select>
-									</div>
+                                                                                </select>
+                                                                        </div>
 
-									<!-- configNeighboursMaxDistanceInMeters -->
-									<div class="p-2">
-										<label class="block text-sm font-medium text-gray-900"
-											>Distanza massima vicini (metri)</label
+                                                                        <!-- configTraceroutesMaxAgeInSeconds -->
+                                                                        <div class="p-2">
+                                                                                <label class="block text-sm font-medium text-gray-900"
+                                                                                        >Età massima tracce</label
+                                                                                >
+                                                                                <div class="text-xs text-gray-600 mb-2">
+                                                                                        Le tracce vengono eliminate oltre questo intervallo. Ricarica per
+                                                                                        aggiornare la mappa.
+                                                                                </div>
+                                                                               <select
+                                                                                       v-model="configTraceroutesMaxAgeInSeconds"
+                                                                                       class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5"
+                                                                               >
+                                                                                       <option
+                                                                                               v-for="option in tracerouteAgeOptions"
+                                                                                               :key="`settings-traceroute-age-${option.value === null ? 'all' : option.value}`"
+                                                                                               :value="option.value"
+                                                                                       >
+                                                                                               {{ option.label }}
+                                                                                       </option>
+                                                                               </select>
+                                                                        </div>
+
+                                                                        <!-- configNeighboursMaxDistanceInMeters -->
+                                                                        <div class="p-2">
+                                                                                <label class="block text-sm font-medium text-gray-900"
+                                                                                        >Distanza massima vicini (metri)</label
 										>
                                                                                 <div class="text-xs text-gray-600 mb-2">
                                                                                         I vicini oltre questa distanza vengono nascosti. Ricarica per aggiornare la
@@ -2783,22 +2847,77 @@
 				return value != null ? parseInt(value) : null;
 			}
 
-			function setConfigWaypointsMaxAgeInSeconds(value) {
-				if (value != null) {
-					return localStorage.setItem(
-						"config_waypoints_max_age_in_seconds",
-						value
-					);
-				} else {
-					return localStorage.removeItem("config_waypoints_max_age_in_seconds");
-				}
-			}
+                        function setConfigWaypointsMaxAgeInSeconds(value) {
+                                if (value != null) {
+                                        return localStorage.setItem(
+                                                "config_waypoints_max_age_in_seconds",
+                                                value
+                                        );
+                                } else {
+                                        return localStorage.removeItem("config_waypoints_max_age_in_seconds");
+                                }
+                        }
 
-			function getConfigNeighboursMaxDistanceInMeters() {
-				const value = localStorage.getItem(
-					"config_neighbours_max_distance_in_meters"
-				);
-				return value != null ? parseInt(value) : null;
+                        function getConfigTraceroutesMaxAgeInSeconds() {
+                                const value = localStorage.getItem(
+                                        "config_traceroutes_max_age_in_seconds"
+                                );
+                                return value != null ? parseInt(value) : null;
+                        }
+
+                        function setConfigTraceroutesMaxAgeInSeconds(value) {
+                                if (value != null) {
+                                        return localStorage.setItem(
+                                                "config_traceroutes_max_age_in_seconds",
+                                                value
+                                        );
+                                } else {
+                                        return localStorage.removeItem(
+                                                "config_traceroutes_max_age_in_seconds"
+                                        );
+                                }
+                        }
+
+                        function filterTraceroutesByMaxAge(
+                                traceroutes,
+                                maxAgeInSeconds,
+                                momentLib
+                        ) {
+                                if (!Array.isArray(traceroutes) || traceroutes.length === 0) {
+                                        return [];
+                                }
+
+                                if (
+                                        maxAgeInSeconds == null ||
+                                        Number.isNaN(Number(maxAgeInSeconds))
+                                ) {
+                                        return traceroutes;
+                                }
+
+                                const momentToUse = momentLib ?? moment;
+                                const now = momentToUse();
+
+                                return traceroutes.filter((traceroute) => {
+                                        const updatedAt = traceroute?.updated_at ?? traceroute?.created_at;
+                                        if (!updatedAt) {
+                                                return true;
+                                        }
+
+                                        const updatedAtMoment = momentToUse(updatedAt);
+                                        if (!updatedAtMoment?.isValid?.()) {
+                                                return true;
+                                        }
+
+                                        const ageInMillis = now.diff(updatedAtMoment);
+                                        return ageInMillis <= maxAgeInSeconds * 1000;
+                                });
+                        }
+
+                        function getConfigNeighboursMaxDistanceInMeters() {
+                                const value = localStorage.getItem(
+                                        "config_neighbours_max_distance_in_meters"
+                                );
+                                return value != null ? parseInt(value) : null;
 			}
 
 			function setConfigNeighboursMaxDistanceInMeters(value) {
@@ -2834,20 +2953,39 @@
 						configNodesMaxAgeInSeconds: window.getConfigNodesMaxAgeInSeconds(),
 						configNodesDisconnectedAgeInSeconds:
 							window.getConfigNodesDisconnectedAgeInSeconds(),
-						configNodesOfflineAgeInSeconds:
-							window.getConfigNodesOfflineAgeInSeconds(),
-						configWaypointsMaxAgeInSeconds:
-							window.getConfigWaypointsMaxAgeInSeconds(),
-						configNeighboursMaxDistanceInMeters:
-							window.getConfigNeighboursMaxDistanceInMeters(),
+                                                configNodesOfflineAgeInSeconds:
+                                                        window.getConfigNodesOfflineAgeInSeconds(),
+                                                configWaypointsMaxAgeInSeconds:
+                                                        window.getConfigWaypointsMaxAgeInSeconds(),
+                                                configTraceroutesMaxAgeInSeconds:
+                                                        window.getConfigTraceroutesMaxAgeInSeconds(),
+                                                configNeighboursMaxDistanceInMeters:
+                                                        window.getConfigNeighboursMaxDistanceInMeters(),
 						configZoomLevelGoToNode: window.getConfigZoomLevelGoToNode(),
 						configAutoUpdatePositionInUrl:
 							window.getConfigAutoUpdatePositionInUrl(),
-						configEnableMapAnimations: window.getConfigEnableMapAnimations(),
-						configTemperatureFormat: window.getConfigTemperatureFormat(),
+                                                configEnableMapAnimations: window.getConfigEnableMapAnimations(),
+                                                configTemperatureFormat: window.getConfigTemperatureFormat(),
 
-						isShowingHardwareModels: false,
-						hardwareModelStats: null,
+                                                tracerouteAgeOptions: [
+                                                        { value: null, label: "Mostra tutto" },
+                                                        { value: 900, label: "15 minuti" },
+                                                        { value: 1800, label: "30 minuti" },
+                                                        { value: 3600, label: "1 ora" },
+                                                        { value: 10800, label: "3 ore" },
+                                                        { value: 21600, label: "6 ore" },
+                                                        { value: 43200, label: "12 ore" },
+                                                        { value: 86400, label: "24 ore" },
+                                                        { value: 172800, label: "2 giorni" },
+                                                        { value: 259200, label: "3 giorni" },
+                                                        { value: 345600, label: "4 giorni" },
+                                                        { value: 432000, label: "5 giorni" },
+                                                        { value: 518400, label: "6 giorni" },
+                                                        { value: 604800, label: "7 giorni" },
+                                                ],
+
+                                                isShowingHardwareModels: false,
+                                                hardwareModelStats: null,
 
 						isShowingInfoModal: this.shouldShowInfoModal(),
 						isShowingMobileSearch: false,
@@ -2859,13 +2997,16 @@
 						selectedNode: null,
 						selectedNodeDeviceMetrics: [],
 						selectedNodeEnvironmentMetrics: [],
-						selectedNodePowerMetrics: [],
-						selectedNodeMqttMetrics: [],
-						selectedNodeTraceroutes: [],
+                                                selectedNodePowerMetrics: [],
+                                                selectedNodeMqttMetrics: [],
+                                                selectedNodeTraceroutes: [],
 
-						deviceMetricsTimeRange: "3d",
-						environmentMetricsTimeRange: "3d",
-						powerMetricsTimeRange: "3d",
+                                                tracerouteAgeTicker: 0,
+                                                tracerouteAgeIntervalId: null,
+
+                                                deviceMetricsTimeRange: "3d",
+                                                environmentMetricsTimeRange: "3d",
+                                                powerMetricsTimeRange: "3d",
 
 						isPositionHistoryModalExpanded: true,
 						positionHistoryDateTimeFrom: null,
@@ -2916,15 +3057,21 @@
 						this.selectedNodeToShowNeighboursType = "heard_us";
 					};
 
-					// handle nodes updated callback from outside of vue
-					window._onNodesUpdated = (nodes) => {
-						this.nodes = nodes;
-					};
-				},
-				methods: {
-					getAnnouncementId: function () {
-						// change this when making a new announcement
-						return "1";
+                                        // handle nodes updated callback from outside of vue
+                                        window._onNodesUpdated = (nodes) => {
+                                                this.nodes = nodes;
+                                        };
+
+                                        this.tracerouteAgeIntervalId = window.setInterval(() => {
+                                                this.tracerouteAgeTicker =
+                                                        (this.tracerouteAgeTicker + 1) % Number.MAX_SAFE_INTEGER;
+                                                renderTraceroutes();
+                                        }, 30 * 1000);
+                                },
+                                methods: {
+                                        getAnnouncementId: function () {
+                                                // change this when making a new announcement
+                                                return "1";
 					},
 					shouldShowAnnouncement: function () {
 						const lastSeenAnnouncementId = window.localStorage.getItem(
@@ -3791,12 +3938,22 @@
 						// only return the first 500 results to avoid ui lag...
 						return nodes.slice(0, 500);
 					},
-					selectedNodeLatestPowerMetric() {
-						const [latestPowerMetric] = this.selectedNodePowerMetrics.slice(-1);
-						return latestPowerMetric;
-					},
-				},
-				watch: {
+                                        selectedNodeLatestPowerMetric() {
+                                                const [latestPowerMetric] = this.selectedNodePowerMetrics.slice(-1);
+                                                return latestPowerMetric;
+                                        },
+                                        filteredSelectedNodeTraceroutes() {
+                                                // include tracerouteAgeTicker so vue recomputes the filtered list as time passes
+                                                void this.tracerouteAgeTicker;
+
+                                                return filterTraceroutesByMaxAge(
+                                                        this.selectedNodeTraceroutes,
+                                                        this.configTraceroutesMaxAgeInSeconds,
+                                                        this.moment
+                                                );
+                                        },
+                                },
+                                watch: {
 					configNodesMaxAgeInSeconds() {
 						window.setConfigNodesMaxAgeInSeconds(
 							this.configNodesMaxAgeInSeconds
@@ -3812,16 +3969,22 @@
 							this.configNodesOfflineAgeInSeconds
 						);
 					},
-					configWaypointsMaxAgeInSeconds() {
-						window.setConfigWaypointsMaxAgeInSeconds(
-							this.configWaypointsMaxAgeInSeconds
-						);
-					},
-					configNeighboursMaxDistanceInMeters() {
-						window.setConfigNeighboursMaxDistanceInMeters(
-							this.configNeighboursMaxDistanceInMeters
-						);
-					},
+                                        configWaypointsMaxAgeInSeconds() {
+                                                window.setConfigWaypointsMaxAgeInSeconds(
+                                                        this.configWaypointsMaxAgeInSeconds
+                                                );
+                                        },
+                                        configTraceroutesMaxAgeInSeconds() {
+                                                window.setConfigTraceroutesMaxAgeInSeconds(
+                                                        this.configTraceroutesMaxAgeInSeconds
+                                                );
+                                                renderTraceroutes();
+                                        },
+                                        configNeighboursMaxDistanceInMeters() {
+                                                window.setConfigNeighboursMaxDistanceInMeters(
+                                                        this.configNeighboursMaxDistanceInMeters
+                                                );
+                                        },
 					configZoomLevelGoToNode() {
 						window.setConfigZoomLevelGoToNode(this.configZoomLevelGoToNode);
 					},
@@ -3851,9 +4014,15 @@
                                                         this.loadNodePowerMetrics(this.selectedNode.node_id);
                                                 }
                                         },
-				},
-			}).mount("#app");
-		</script>
+                                },
+                                unmounted() {
+                                        if (this.tracerouteAgeIntervalId != null) {
+                                                window.clearInterval(this.tracerouteAgeIntervalId);
+                                                this.tracerouteAgeIntervalId = null;
+                                        }
+                                },
+                        }).mount("#app");
+                </script>
 
 		<script>
                         // global state
@@ -4608,7 +4777,17 @@
                                         return;
                                 }
 
-                                for (const traceroute of traceroutes) {
+                                const traceroutesToRender = filterTraceroutesByMaxAge(
+                                        traceroutes,
+                                        getConfigTraceroutesMaxAgeInSeconds(),
+                                        moment
+                                );
+
+                                if (!Array.isArray(traceroutesToRender) || traceroutesToRender.length === 0) {
+                                        return;
+                                }
+
+                                for (const traceroute of traceroutesToRender) {
                                         const pathNodeIds = [];
 
                                         if (traceroute?.to != null) {


### PR DESCRIPTION
## Summary
- add a traceroute age selector to the header toolbar so the retention limit is visible in the main web UI
- centralize the traceroute age options and reuse them for the node panel and settings dropdowns to keep the controls consistent

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cb43fa7a548323a3f16769b8cf04e8