### PR TITLE
Track neighbour and traceroute first/last seen timestamps

### DIFF
--- a/api/src/routes/neighbours.ts
+++ b/api/src/routes/neighbours.ts
@@ -49,6 +49,7 @@ express.get("/api/v1/nodes/:nodeId/neighbours", async (req, res) => {
 			nodes_that_we_heard: node.neighbours.map((neighbour) => {
 				return {
 					...(neighbour as object),
+					first_seen_at: node.neighbours_first_seen_at,
 					updated_at: node.neighbours_updated_at,
 				};
 			}),
@@ -82,6 +83,7 @@ express.get("/api/v1/nodes/:nodeId/neighbours", async (req, res) => {
 				return {
 					node_id: Number(nodeThatHeardUs.node_id),
 					snr: neighbourInfo.snr,
+					first_seen_at: nodeThatHeardUs.neighbours_first_seen_at,
 					updated_at: nodeThatHeardUs.neighbours_updated_at,
 				};
 			}),

--- a/app/public/index.html
+++ b/app/public/index.html
@@ -1822,55 +1822,73 @@
 										<div class="bg-gray-200 p-2 font-semibold">Altro</div>
 										<ul role="list" class="flex-1 divide-y divide-gray-200">
 											<!-- first seen -->
-											<li class="flex p-3">
-												<div class="text-sm font-medium text-gray-900">
-													Prima rilevazione
-												</div>
-												<div class="ml-auto text-sm text-gray-700">
-													{{ moment(new Date(selectedNode.created_at)).fromNow()
-													}}
-												</div>
-											</li>
+                                                                                        <li class="flex p-3">
+                                                                                                <div class="text-sm font-medium text-gray-900">
+                                                                                                        Prima rilevazione
+                                                                                                </div>
+                                                                                                <div class="ml-auto text-sm text-gray-700">
+                                                                                                        {{ formatRelativeAndExactTimestampText(selectedNode.created_at) }}
+                                                                                                </div>
+                                                                                        </li>
 
 											<!-- last seen -->
-											<li class="flex p-3">
-												<div class="text-sm font-medium text-gray-900">
-													Ultima rilevazione
-												</div>
-												<div class="ml-auto text-sm text-gray-700">
-													{{ moment(new Date(selectedNode.updated_at)).fromNow()
-													}}
-												</div>
-											</li>
+                                                                                        <li class="flex p-3">
+                                                                                                <div class="text-sm font-medium text-gray-900">
+                                                                                                        Ultima rilevazione
+                                                                                                </div>
+                                                                                                <div class="ml-auto text-sm text-gray-700">
+                                                                                                        {{ formatRelativeAndExactTimestampText(selectedNode.updated_at) }}
+                                                                                                </div>
+                                                                                        </li>
 
-											<!-- neighbours updated -->
-											<li class="flex p-3">
-												<div class="text-sm font-medium text-gray-900">
-													Aggiornamento vicini
-												</div>
-												<div class="ml-auto text-sm text-gray-700">
-													<span v-if="selectedNode.neighbours_updated_at"
-														>{{ moment(new
-														Date(selectedNode.neighbours_updated_at)).fromNow()
-														}}</span
-													>
-													<span v-else>???</span>
-												</div>
-											</li>
+                                                                                        <!-- neighbours first seen -->
+                                                                                        <li class="flex p-3">
+                                                                                                <div class="text-sm font-medium text-gray-900">
+                                                                                                        Prima info vicini
+                                                                                                </div>
+                                                                                                <div class="ml-auto text-sm text-gray-700">
+                                                                                                        {{ formatRelativeAndExactTimestampText(selectedNode.neighbours_first_seen_at) }}
+                                                                                                </div>
+                                                                                        </li>
 
-											<!-- position updated -->
-											<li class="flex p-3">
-												<div class="text-sm font-medium text-gray-900">
-													Aggiornamento posizione
+                                                                                        <!-- neighbours updated -->
+                                                                                        <li class="flex p-3">
+                                                                                                <div class="text-sm font-medium text-gray-900">
+                                                                                                        Aggiornamento vicini
+                                                                                                </div>
+                                                                                                <div class="ml-auto text-sm text-gray-700">
+                                                                                                        {{ formatRelativeAndExactTimestampText(selectedNode.neighbours_updated_at) }}
+                                                                                                </div>
+                                                                                        </li>
+
+                                                                                        <!-- traceroutes first seen -->
+                                                                                        <li class="flex p-3">
+                                                                                                <div class="text-sm font-medium text-gray-900">
+                                                                                                        Prima info traceroute
+                                                                                                </div>
+                                                                                                <div class="ml-auto text-sm text-gray-700">
+                                                                                                        {{ formatRelativeAndExactTimestampText(selectedNode.traceroutes_first_seen_at) }}
+                                                                                                </div>
+                                                                                        </li>
+
+                                                                                        <!-- traceroutes updated -->
+                                                                                        <li class="flex p-3">
+                                                                                                <div class="text-sm font-medium text-gray-900">
+                                                                                                        Aggiornamento traceroute
+                                                                                                </div>
+                                                                                                <div class="ml-auto text-sm text-gray-700">
+                                                                                                        {{ formatRelativeAndExactTimestampText(selectedNode.traceroutes_updated_at) }}
+                                                                                                </div>
+                                                                                        </li>
+
+                                                                                        <!-- position updated -->
+                                                                                        <li class="flex p-3">
+                                                                                                <div class="text-sm font-medium text-gray-900">
+                                                                                                        Aggiornamento posizione
 												</div>
-												<div class="ml-auto text-sm text-gray-700">
-													<span v-if="selectedNode.position_updated_at"
-														>{{ moment(new
-														Date(selectedNode.position_updated_at)).fromNow()
-														}}</span
-													>
-													<span v-else>???</span>
-												</div>
+                                                                                                <div class="ml-auto text-sm text-gray-700">
+                                                                                                        {{ formatRelativeAndExactTimestampText(selectedNode.position_updated_at) }}
+                                                                                                </div>
 											</li>
 										</ul>
 									</div>
@@ -3009,6 +3027,24 @@
                                 return "Età sconosciuta";
                         }
 
+                        function formatRelativeAndExactTimestampLabel(
+                                timestamp,
+                                momentLib = moment,
+                        ) {
+                                if (!timestamp) {
+                                        return null;
+                                }
+
+                                const momentFn = typeof momentLib === "function" ? momentLib : moment;
+                                const momentInstance = momentFn(timestamp);
+
+                                if (!momentInstance?.isValid?.()) {
+                                        return null;
+                                }
+
+                                return `${momentInstance.fromNow()} (${momentInstance.format("DD/MM/YYYY HH:mm")})`;
+                        }
+
                         function hasNeighbourInfoExpired(
                                 neighboursUpdatedAt,
                                 maxAgeInSeconds,
@@ -3215,6 +3251,14 @@
                                         },
                                         formatTracerouteAgeLabel: function (traceroute) {
                                                 return getTracerouteAgeLabel(traceroute, this.moment);
+                                        },
+                                        formatRelativeAndExactTimestampText: function (timestamp) {
+                                                return (
+                                                        formatRelativeAndExactTimestampLabel(
+                                                                timestamp,
+                                                                this.moment,
+                                                        ) ?? "???"
+                                                );
                                         },
                                         getTracerouteHopCount: function (traceroute) {
                                                 if (!traceroute || !Array.isArray(traceroute.route)) {
@@ -4767,14 +4811,30 @@
 
 					const terrainImageUrl = getTerrainProfileImage(node, neighbourNode);
 
-					const tooltip = `<b>[${escapeString(node.short_name)}] ${escapeString(node.long_name)}</b> heard <b>[${escapeString(neighbourNode.short_name)}] ${escapeString(neighbourNode.long_name)}</b>`
-                + `<br/>SNR: ${neighbour.snr}dB`
-                + `<br/>Distance: ${distance}`
-                + `<br/><br/>ID: ${node.node_id} heard ${neighbourNode.node_id}`
-                + `<br/>ID esadecimale: ${node.node_id_hex} heard ${neighbourNode.node_id_hex}`
-                + (node.neighbours_updated_at ? `<br/>Aggiornamento: ${moment(new Date(node.neighbours_updated_at)).fromNow()}` : '')
-                + `<br/><br/>Terrain images from <a href="http://www.heywhatsthat.com" target="_blank">HeyWhatsThat.com</a>`
-                + `<br/><a href="${terrainImageUrl}" target="_blank"><img src="${terrainImageUrl}" width="100%"></a>`;
+                                        let tooltip = `<b>[${escapeString(node.short_name)}] ${escapeString(node.long_name)}</b> heard <b>[${escapeString(neighbourNode.short_name)}] ${escapeString(neighbourNode.long_name)}</b>`;
+                                        tooltip += `<br/>SNR: ${neighbour.snr}dB`;
+                                        tooltip += `<br/>Distance: ${distance}`;
+                                        tooltip += `<br/><br/>ID: ${node.node_id} heard ${neighbourNode.node_id}`;
+                                        tooltip += `<br/>ID esadecimale: ${node.node_id_hex} heard ${neighbourNode.node_id_hex}`;
+
+                                        const nodeNeighboursFirstSeenLabel = formatRelativeAndExactTimestampLabel(
+                                                node.neighbours_first_seen_at,
+                                                moment,
+                                        );
+                                        if (nodeNeighboursFirstSeenLabel) {
+                                                tooltip += `<br/>Prima info: ${nodeNeighboursFirstSeenLabel}`;
+                                        }
+
+                                        const nodeNeighboursUpdatedLabel = formatRelativeAndExactTimestampLabel(
+                                                node.neighbours_updated_at,
+                                                moment,
+                                        );
+                                        if (nodeNeighboursUpdatedLabel) {
+                                                tooltip += `<br/>Aggiornamento: ${nodeNeighboursUpdatedLabel}`;
+                                        }
+
+                                        tooltip += `<br/><br/>Terrain images from <a href="http://www.heywhatsthat.com" target="_blank">HeyWhatsThat.com</a>`;
+                                        tooltip += `<br/><a href="${terrainImageUrl}" target="_blank"><img src="${terrainImageUrl}" width="100%"></a>`;
 
 					line
 						.bindTooltip(tooltip, {
@@ -4919,14 +4979,30 @@
 
 					const terrainImageUrl = getTerrainProfileImage(neighbourNode, node);
 
-					const tooltip = `<b>[${escapeString(neighbourNode.short_name)}] ${escapeString(neighbourNode.long_name)}</b> heard <b>[${escapeString(node.short_name)}] ${escapeString(node.long_name)}</b>`
-                + `<br/>SNR: ${neighbour.snr}dB`
-                + `<br/>Distance: ${distance}`
-                + `<br/><br/>ID: ${neighbourNode.node_id} heard ${node.node_id}`
-                + `<br/>ID esadecimale: ${neighbourNode.node_id_hex} heard ${node.node_id_hex}`
-                + (neighbourNode.neighbours_updated_at ? `<br/>Aggiornamento: ${moment(new Date(neighbourNode.neighbours_updated_at)).fromNow()}` : '')
-                + `<br/><br/>Terrain images from <a href="http://www.heywhatsthat.com" target="_blank">HeyWhatsThat.com</a>`
-                + `<br/><a href="${terrainImageUrl}" target="_blank"><img src="${terrainImageUrl}" width="100%"></a>`;
+                                        let tooltip = `<b>[${escapeString(neighbourNode.short_name)}] ${escapeString(neighbourNode.long_name)}</b> heard <b>[${escapeString(node.short_name)}] ${escapeString(node.long_name)}</b>`;
+                                        tooltip += `<br/>SNR: ${neighbour.snr}dB`;
+                                        tooltip += `<br/>Distance: ${distance}`;
+                                        tooltip += `<br/><br/>ID: ${neighbourNode.node_id} heard ${node.node_id}`;
+                                        tooltip += `<br/>ID esadecimale: ${neighbourNode.node_id_hex} heard ${node.node_id_hex}`;
+
+                                        const neighbourFirstSeenLabel = formatRelativeAndExactTimestampLabel(
+                                                neighbourNode.neighbours_first_seen_at,
+                                                moment,
+                                        );
+                                        if (neighbourFirstSeenLabel) {
+                                                tooltip += `<br/>Prima info: ${neighbourFirstSeenLabel}`;
+                                        }
+
+                                        const neighbourUpdatedLabel = formatRelativeAndExactTimestampLabel(
+                                                neighbourNode.neighbours_updated_at,
+                                                moment,
+                                        );
+                                        if (neighbourUpdatedLabel) {
+                                                tooltip += `<br/>Aggiornamento: ${neighbourUpdatedLabel}`;
+                                        }
+
+                                        tooltip += `<br/><br/>Terrain images from <a href="http://www.heywhatsthat.com" target="_blank">HeyWhatsThat.com</a>`;
+                                        tooltip += `<br/><a href="${terrainImageUrl}" target="_blank"><img src="${terrainImageUrl}" width="100%"></a>`;
 
 					line
 						.bindTooltip(tooltip, {
@@ -5453,14 +5529,30 @@
 
 							const terrainImageUrl = getTerrainProfileImage(node, neighbourNode);
 
-							const tooltip = `<b>[${escapeString(node.short_name)}] ${escapeString(node.long_name)}</b> heard <b>[${escapeString(neighbourNode.short_name)}] ${escapeString(neighbourNode.long_name)}</b>`
-								+ `<br/>SNR: ${neighbour.snr}dB`
-								+ `<br/>Distance: ${distance}`
-								+ `<br/><br/>ID: ${node.node_id} heard ${neighbourNode.node_id}`
-								+ `<br/>ID esadecimale: ${node.node_id_hex} heard ${neighbourNode.node_id_hex}`
-								+ (node.neighbours_updated_at ? `<br/>Aggiornamento: ${moment(new Date(node.neighbours_updated_at)).fromNow()}` : '')
-								+ `<br/><br/>Terrain images from <a href="http://www.heywhatsthat.com" target="_blank">HeyWhatsThat.com</a>`
-								+ `<br/><a href="${terrainImageUrl}" target="_blank"><img src="${terrainImageUrl}" width="100%"></a>`;
+                                                        let tooltip = `<b>[${escapeString(node.short_name)}] ${escapeString(node.long_name)}</b> heard <b>[${escapeString(neighbourNode.short_name)}] ${escapeString(neighbourNode.long_name)}</b>`;
+                                                        tooltip += `<br/>SNR: ${neighbour.snr}dB`;
+                                                        tooltip += `<br/>Distance: ${distance}`;
+                                                        tooltip += `<br/><br/>ID: ${node.node_id} heard ${neighbourNode.node_id}`;
+                                                        tooltip += `<br/>ID esadecimale: ${node.node_id_hex} heard ${neighbourNode.node_id_hex}`;
+
+                                                        const nodeFirstSeenLabel = formatRelativeAndExactTimestampLabel(
+                                                                node.neighbours_first_seen_at,
+                                                                moment,
+                                                        );
+                                                        if (nodeFirstSeenLabel) {
+                                                                tooltip += `<br/>Prima info: ${nodeFirstSeenLabel}`;
+                                                        }
+
+                                                        const nodeUpdatedLabel = formatRelativeAndExactTimestampLabel(
+                                                                node.neighbours_updated_at,
+                                                                moment,
+                                                        );
+                                                        if (nodeUpdatedLabel) {
+                                                                tooltip += `<br/>Aggiornamento: ${nodeUpdatedLabel}`;
+                                                        }
+
+                                                        tooltip += `<br/><br/>Terrain images from <a href="http://www.heywhatsthat.com" target="_blank">HeyWhatsThat.com</a>`;
+                                                        tooltip += `<br/><a href="${terrainImageUrl}" target="_blank"><img src="${terrainImageUrl}" width="100%"></a>`;
 
 							line
 								.bindTooltip(tooltip, {
@@ -5910,19 +6002,53 @@
 				// bottom info
 				tooltip += `<br/><br/>ID: ${node.node_id}`;
 				tooltip += `<br/>ID esadecimale: ${node.node_id_hex}`;
-				tooltip += `<br/>Aggiornamento: ${moment(
-					new Date(node.updated_at)
-				).fromNow()}`;
-				tooltip += node.neighbours_updated_at
-					? `<br/>Aggiornamento vicini: ${moment(
-							new Date(node.neighbours_updated_at)
-					  ).fromNow()}`
-					: "";
-				tooltip += node.position_updated_at
-					? `<br/>Aggiornamento posizione: ${moment(
-							new Date(node.position_updated_at)
-					  ).fromNow()}`
-					: "";
+                                const nodeUpdatedLabel = formatRelativeAndExactTimestampLabel(
+                                        node.updated_at,
+                                        moment,
+                                );
+                                if (nodeUpdatedLabel) {
+                                        tooltip += `<br/>Aggiornamento: ${nodeUpdatedLabel}`;
+                                }
+
+                                const neighboursFirstSeenLabel = formatRelativeAndExactTimestampLabel(
+                                        node.neighbours_first_seen_at,
+                                        moment,
+                                );
+                                if (neighboursFirstSeenLabel) {
+                                        tooltip += `<br/>Prima info vicini: ${neighboursFirstSeenLabel}`;
+                                }
+
+                                const neighboursUpdatedLabel = formatRelativeAndExactTimestampLabel(
+                                        node.neighbours_updated_at,
+                                        moment,
+                                );
+                                if (neighboursUpdatedLabel) {
+                                        tooltip += `<br/>Aggiornamento vicini: ${neighboursUpdatedLabel}`;
+                                }
+
+                                const traceroutesFirstSeenLabel = formatRelativeAndExactTimestampLabel(
+                                        node.traceroutes_first_seen_at,
+                                        moment,
+                                );
+                                if (traceroutesFirstSeenLabel) {
+                                        tooltip += `<br/>Prima info traceroute: ${traceroutesFirstSeenLabel}`;
+                                }
+
+                                const traceroutesUpdatedLabel = formatRelativeAndExactTimestampLabel(
+                                        node.traceroutes_updated_at,
+                                        moment,
+                                );
+                                if (traceroutesUpdatedLabel) {
+                                        tooltip += `<br/>Aggiornamento traceroute: ${traceroutesUpdatedLabel}`;
+                                }
+
+                                const positionUpdatedLabel = formatRelativeAndExactTimestampLabel(
+                                        node.position_updated_at,
+                                        moment,
+                                );
+                                if (positionUpdatedLabel) {
+                                        tooltip += `<br/>Aggiornamento posizione: ${positionUpdatedLabel}`;
+                                }
 
 				// show details button
 				tooltip += `<br/><br/><button onclick="showNodeDetails(${node.node_id});" class="border border-gray-300 bg-gray-100 p-1 w-full rounded hover:bg-gray-200 mb-1">Mostra dettagli completi</button>`;

--- a/prisma/migrations/20241206000000_add_trace_and_neighbour_seen_columns/migration.sql
+++ b/prisma/migrations/20241206000000_add_trace_and_neighbour_seen_columns/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `nodes`
+    ADD COLUMN `neighbours_first_seen_at` DATETIME(3) NULL,
+    ADD COLUMN `traceroutes_first_seen_at` DATETIME(3) NULL,
+    ADD COLUMN `traceroutes_updated_at` DATETIME(3) NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,10 +46,14 @@ model Node {
 
     neighbour_broadcast_interval_secs Int?
     neighbours                        Json?
+    neighbours_first_seen_at          DateTime?
     neighbours_updated_at             DateTime?
 
     // this column tracks when an mqtt gateway node uplinked a packet
     mqtt_connection_state_updated_at DateTime?
+
+    traceroutes_first_seen_at DateTime?
+    traceroutes_updated_at    DateTime?
 
     created_at DateTime @default(now())
     updated_at DateTime @default(now()) @updatedAt


### PR DESCRIPTION
## Summary
- add first_seen/updated columns for neighbour and traceroute activity on nodes together with a schema migration
- persist neighbour/traceroute timestamps when MQTT packets arrive and expose first_seen_at data from the API
- surface the new timing details across the map UI with clearer relative+absolute timestamp formatting in node sidebars, overlays, and tooltips

## Testing
- npm --prefix mqtt run check
- npm --prefix api run check
- npm --prefix app run check

------
https://chatgpt.com/codex/tasks/task_e_68dbf431dd748323a5989755d42b8fdf