### PR TITLE
Clarify traceroute and neighbour tooltip timestamps

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -3180,16 +3180,52 @@
                                         return null;
                                 }
 
-                                const tracerouteAge = traceroute.age_in_seconds;
-                                if (
-                                        typeof tracerouteAge === "number" &&
+                                const momentToUse = momentLib ?? moment;
+                                const rawTracerouteAge = traceroute.age_in_seconds;
+                                const tracerouteAge =
+                                        typeof rawTracerouteAge === "number"
+                                                ? rawTracerouteAge
+                                                : Number(rawTracerouteAge);
+                                const hasTracerouteAge =
+                                        rawTracerouteAge != null &&
+                                        rawTracerouteAge !== "" &&
                                         Number.isFinite(tracerouteAge) &&
-                                        tracerouteAge >= 0
-                                ) {
+                                        tracerouteAge >= 0;
+                                if (hasTracerouteAge) {
+                                        const ageRetrievedAtMs = traceroute.age_in_seconds_retrieved_at_ms;
+                                        if (
+                                                typeof ageRetrievedAtMs === "number" &&
+                                                Number.isFinite(ageRetrievedAtMs)
+                                        ) {
+                                                const additionalMillis = Date.now() - ageRetrievedAtMs;
+                                                if (
+                                                        Number.isFinite(additionalMillis) &&
+                                                        additionalMillis >= 0
+                                                ) {
+                                                        return tracerouteAge + additionalMillis / 1000;
+                                                }
+                                        }
+
+                                        const ageRetrievedAt = traceroute.age_in_seconds_retrieved_at;
+                                        if (ageRetrievedAt != null) {
+                                                const ageRetrievedAtMoment = momentToUse(ageRetrievedAt);
+                                                if (ageRetrievedAtMoment?.isValid?.()) {
+                                                        const additionalSeconds = momentToUse().diff(
+                                                                ageRetrievedAtMoment,
+                                                                "seconds",
+                                                        );
+                                                        if (
+                                                                Number.isFinite(additionalSeconds) &&
+                                                                additionalSeconds >= 0
+                                                        ) {
+                                                                return tracerouteAge + additionalSeconds;
+                                                        }
+                                                }
+                                        }
+
                                         return tracerouteAge;
                                 }
 
-                                const momentToUse = momentLib ?? moment;
                                 const updatedAt = traceroute?.updated_at ?? traceroute?.created_at;
                                 if (!updatedAt) {
                                         return null;
@@ -3270,7 +3306,11 @@
                                         return null;
                                 }
 
-                                return `${momentInstance.fromNow()} (${momentInstance.format("DD/MM/YYYY HH:mm")})`;
+                                const relativeLabel = momentInstance.fromNow();
+                                const exactLabel = momentInstance.format("DD/MM/YYYY HH:mm:ss");
+                                const utcOffset = momentInstance.format("Z");
+
+                                return `${relativeLabel} (${exactLabel} UTC${utcOffset})`;
                         }
 
                         function buildPacketSeenTooltipSection({
@@ -3317,6 +3357,55 @@
                                 }
 
                                 return tooltipSection;
+                        }
+
+                        function getFirstNonEmptyTimestampValue(...values) {
+                                for (const value of values) {
+                                        if (value == null) {
+                                                continue;
+                                        }
+
+                                        if (typeof value === "string" && value.trim() === "") {
+                                                continue;
+                                        }
+
+                                        return value;
+                                }
+
+                                return null;
+                        }
+
+                        function getNeighbourConnectionTimestamps({
+                                neighbour = null,
+                                sourceNode = null,
+                                targetNode = null,
+                        } = {}) {
+                                const firstSeenAt = getFirstNonEmptyTimestampValue(
+                                        neighbour?.first_seen_at,
+                                        neighbour?.firstSeenAt,
+                                        neighbour?.first_seen,
+                                        neighbour?.firstSeen,
+                                        neighbour?.first_heard_at,
+                                        neighbour?.firstHeardAt,
+                                        sourceNode?.neighbours_first_seen_at,
+                                        targetNode?.neighbours_first_seen_at,
+                                );
+
+                                const updatedAt = getFirstNonEmptyTimestampValue(
+                                        neighbour?.updated_at,
+                                        neighbour?.updatedAt,
+                                        neighbour?.last_seen_at,
+                                        neighbour?.lastSeenAt,
+                                        neighbour?.last_heard_at,
+                                        neighbour?.lastHeardAt,
+                                        sourceNode?.neighbours_updated_at,
+                                        targetNode?.neighbours_updated_at,
+                                );
+
+                                return {
+                                        firstSeenAt,
+                                        updatedAt,
+                                };
                         }
 
                         function hasNeighbourInfoExpired(
@@ -3723,8 +3812,10 @@
 								params: {
 									count: 5,
 								},
-							})
+                                                        })
                                                         .then((response) => {
+                                                                const ageRetrievedAtMs = Date.now();
+                                                                const ageRetrievedAt = new Date(ageRetrievedAtMs).toISOString();
                                                                 const traceroutes = Array.isArray(response.data.traceroutes)
                                                                         ? response.data.traceroutes
                                                                         : [];
@@ -3737,6 +3828,8 @@
 
                                                                         return {
                                                                                 ...traceroute,
+                                                                                age_in_seconds_retrieved_at: ageRetrievedAt,
+                                                                                age_in_seconds_retrieved_at_ms: ageRetrievedAtMs,
                                                                                 total_distance_meters: totalDistanceInMeters,
                                                                                 total_distance_label: totalDistanceLabel,
                                                                                 snr_towards_label:
@@ -5330,13 +5423,19 @@
                                                 distanceLabelForModal = `${(distanceInMetersNumber / 1000).toFixed(2)} km`;
                                         }
 
+                                        const neighbourTimestamps = getNeighbourConnectionTimestamps({
+                                                neighbour: neighbour,
+                                                sourceNode: node,
+                                                targetNode: neighbourNode,
+                                        });
+
                                         neighboursForModal.push({
                                                 node: neighbourNode,
                                                 node_id: neighbourNode.node_id,
                                                 distance_in_meters: distanceInMetersNumber,
                                                 distance_label: distanceLabelForModal,
-                                                first_seen_at: node.neighbours_first_seen_at,
-                                                updated_at: node.neighbours_updated_at,
+                                                first_seen_at: neighbourTimestamps.firstSeenAt,
+                                                updated_at: neighbourTimestamps.updatedAt,
                                                 quality: neighbourQuality,
                                                 direction: "we_heard",
                                         });
@@ -5348,6 +5447,15 @@
                                         const rssiLabel =
                                                 neighbourQuality.rssiLabel ?? "N/D";
 
+                                        const neighbourFirstSeenLabel = formatRelativeAndExactTimestampLabel(
+                                                neighbourTimestamps.firstSeenAt,
+                                                moment,
+                                        );
+                                        const neighbourUpdatedLabel = formatRelativeAndExactTimestampLabel(
+                                                neighbourTimestamps.updatedAt,
+                                                moment,
+                                        );
+
                                         let tooltip = `<b>[${escapeString(node.short_name)}] ${escapeString(node.long_name)}</b> heard <b>[${escapeString(neighbourNode.short_name)}] ${escapeString(neighbourNode.long_name)}</b>`;
                                         tooltip += `<br/>SNR (ricezione): ${escapeString(snrLabel)}`;
                                         tooltip += `<br/>RSSI (ricezione): ${escapeString(rssiLabel)}`;
@@ -5355,9 +5463,17 @@
                                         tooltip += `<br/><br/>ID: ${node.node_id} heard ${neighbourNode.node_id}`;
                                         tooltip += `<br/>ID esadecimale: ${node.node_id_hex} heard ${neighbourNode.node_id_hex}`;
 
+                                        if (neighbourFirstSeenLabel) {
+                                                tooltip += `<br/>Creazione vicini: ${escapeString(neighbourFirstSeenLabel)}`;
+                                        }
+
+                                        if (neighbourUpdatedLabel) {
+                                                tooltip += `<br/>Ultimo aggiornamento vicini: ${escapeString(neighbourUpdatedLabel)}`;
+                                        }
+
                                         tooltip += buildPacketSeenTooltipSection({
-                                                firstSeenAt: node.neighbours_first_seen_at,
-                                                lastSeenAt: node.neighbours_updated_at,
+                                                firstSeenAt: neighbourTimestamps.firstSeenAt,
+                                                lastSeenAt: neighbourTimestamps.updatedAt,
                                                 packetTypeLabel: "Pacchetti vicini ricevuti",
                                                 sourceName: getNodeDisplayLabel(node, node.node_id),
                                                 momentLib: moment,
@@ -5370,16 +5486,16 @@
                                         tooltip += `<br/><br/>Terrain images from <a href="http://www.heywhatsthat.com" target="_blank">HeyWhatsThat.com</a>`;
                                         tooltip += `<br/><a href="${terrainImageUrl}" target="_blank"><img src="${terrainImageUrl}" width="100%"></a>`;
 
-					line
-						.bindTooltip(tooltip, {
-							sticky: true,
-							opacity: 1,
-							interactive: true,
-						})
-						.bindPopup(tooltip)
-						.on("click", function (event) {
-							// close tooltip on click to prevent tooltip and popup showing at same time
-							event.target.closeTooltip();
+                                        line
+                                                .bindTooltip(tooltip, {
+                                                        sticky: true,
+                                                        opacity: 1,
+                                                        interactive: true,
+                                                })
+                                                .bindPopup(tooltip)
+                                                .on("click", function (event) {
+                                                        // close tooltip on click to prevent tooltip and popup showing at same time
+                                                        event.target.closeTooltip();
                                                 });
                                 }
 
@@ -5531,13 +5647,19 @@
                                                 distanceLabelForModal = `${(distanceInMetersNumber / 1000).toFixed(2)} km`;
                                         }
 
+                                        const neighbourTimestamps = getNeighbourConnectionTimestamps({
+                                                neighbour: neighbour,
+                                                sourceNode: neighbourNode,
+                                                targetNode: node,
+                                        });
+
                                         neighboursForModal.push({
                                                 node: neighbourNode,
                                                 node_id: neighbourNode.node_id,
                                                 distance_in_meters: distanceInMetersNumber,
                                                 distance_label: distanceLabelForModal,
-                                                first_seen_at: neighbourNode.neighbours_first_seen_at,
-                                                updated_at: neighbourNode.neighbours_updated_at,
+                                                first_seen_at: neighbourTimestamps.firstSeenAt,
+                                                updated_at: neighbourTimestamps.updatedAt,
                                                 quality: neighbourQuality,
                                                 direction: "heard_us",
                                         });
@@ -5549,6 +5671,15 @@
                                         const rssiLabel =
                                                 neighbourQuality.rssiLabel ?? "N/D";
 
+                                        const neighbourFirstSeenLabel = formatRelativeAndExactTimestampLabel(
+                                                neighbourTimestamps.firstSeenAt,
+                                                moment,
+                                        );
+                                        const neighbourUpdatedLabel = formatRelativeAndExactTimestampLabel(
+                                                neighbourTimestamps.updatedAt,
+                                                moment,
+                                        );
+
                                         let tooltip = `<b>[${escapeString(neighbourNode.short_name)}] ${escapeString(neighbourNode.long_name)}</b> heard <b>[${escapeString(node.short_name)}] ${escapeString(node.long_name)}</b>`;
                                         tooltip += `<br/>SNR (trasmissione): ${escapeString(snrLabel)}`;
                                         tooltip += `<br/>RSSI (trasmissione): ${escapeString(rssiLabel)}`;
@@ -5556,9 +5687,17 @@
                                         tooltip += `<br/><br/>ID: ${neighbourNode.node_id} heard ${node.node_id}`;
                                         tooltip += `<br/>ID esadecimale: ${neighbourNode.node_id_hex} heard ${node.node_id_hex}`;
 
+                                        if (neighbourFirstSeenLabel) {
+                                                tooltip += `<br/>Creazione vicini: ${escapeString(neighbourFirstSeenLabel)}`;
+                                        }
+
+                                        if (neighbourUpdatedLabel) {
+                                                tooltip += `<br/>Ultimo aggiornamento vicini: ${escapeString(neighbourUpdatedLabel)}`;
+                                        }
+
                                         tooltip += buildPacketSeenTooltipSection({
-                                                firstSeenAt: neighbourNode.neighbours_first_seen_at,
-                                                lastSeenAt: neighbourNode.neighbours_updated_at,
+                                                firstSeenAt: neighbourTimestamps.firstSeenAt,
+                                                lastSeenAt: neighbourTimestamps.updatedAt,
                                                 packetTypeLabel: "Pacchetti vicini ricevuti",
                                                 sourceName: getNodeDisplayLabel(
                                                         neighbourNode,
@@ -5574,16 +5713,16 @@
                                         tooltip += `<br/><br/>Terrain images from <a href="http://www.heywhatsthat.com" target="_blank">HeyWhatsThat.com</a>`;
                                         tooltip += `<br/><a href="${terrainImageUrl}" target="_blank"><img src="${terrainImageUrl}" width="100%"></a>`;
 
-					line
-						.bindTooltip(tooltip, {
-							sticky: true,
-							opacity: 1,
-							interactive: true,
-						})
-						.bindPopup(tooltip)
-						.on("click", function (event) {
-							// close tooltip on click to prevent tooltip and popup showing at same time
-							event.target.closeTooltip();
+                                        line
+                                                .bindTooltip(tooltip, {
+                                                        sticky: true,
+                                                        opacity: 1,
+                                                        interactive: true,
+                                                })
+                                                .bindPopup(tooltip)
+                                                .on("click", function (event) {
+                                                        // close tooltip on click to prevent tooltip and popup showing at same time
+                                                        event.target.closeTooltip();
                                                 });
                                 }
 
@@ -5805,109 +5944,115 @@
 
                                         const hopCount = Math.max(pathNodeIds.length - 1, 0);
 
-                                        let tooltip = `<b>Traceroute #${traceroute.id}</b>`;
-                                        const tracerouteAgeLabel = getTracerouteAgeLabel(traceroute, moment);
-                                        if (tracerouteAgeLabel) {
-                                                tooltip += `<br/>Età: ${escapeString(tracerouteAgeLabel)}`;
-                                        }
+                                        const buildTracerouteTooltipContent = () => {
+                                                let tooltip = `<b>Traceroute #${traceroute.id}</b>`;
+                                                const tracerouteAgeLabel = getTracerouteAgeLabel(traceroute, moment);
+                                                if (tracerouteAgeLabel) {
+                                                        tooltip += `<br/>Età: ${escapeString(tracerouteAgeLabel)}`;
+                                                }
 
-                                        const tracerouteFirstSeenLabel = formatRelativeAndExactTimestampLabel(
-                                                traceroute.created_at,
-                                                moment,
-                                        );
-                                        if (tracerouteFirstSeenLabel) {
-                                                tooltip += `<br/>Prima info traceroute: ${escapeString(tracerouteFirstSeenLabel)}`;
-                                        }
+                                                const tracerouteFirstSeenLabel = formatRelativeAndExactTimestampLabel(
+                                                        traceroute.created_at,
+                                                        moment,
+                                                );
+                                                if (tracerouteFirstSeenLabel) {
+                                                        tooltip += `<br/>Creazione traceroute: ${escapeString(tracerouteFirstSeenLabel)}`;
+                                                }
 
-                                        const tracerouteUpdatedLabel = formatRelativeAndExactTimestampLabel(
-                                                traceroute.updated_at,
-                                                moment,
-                                        );
-                                        if (tracerouteUpdatedLabel) {
-                                                tooltip += `<br/>Aggiornamento traceroute: ${escapeString(tracerouteUpdatedLabel)}`;
-                                        }
+                                                const tracerouteUpdatedLabel = formatRelativeAndExactTimestampLabel(
+                                                        traceroute.updated_at,
+                                                        moment,
+                                                );
+                                                if (tracerouteUpdatedLabel) {
+                                                        tooltip += `<br/>Ultimo aggiornamento traceroute: ${escapeString(tracerouteUpdatedLabel)}`;
+                                                }
 
-                                        if (traceroute.from != null) {
-                                                const tracerouteInitiatorNode = findNodeById(traceroute.from);
-                                                const initiatorDetail =
+                                                if (traceroute.from != null) {
+                                                        const tracerouteInitiatorNode = findNodeById(traceroute.from);
+                                                        const initiatorDetail =
+                                                                traceroute.to != null &&
+                                                                traceroute.to === traceroute.from
+                                                                        ? "(nodo che ha avviato e risposto al traceroute)"
+                                                                        : "(nodo che ha avviato il traceroute)";
+                                                        const initiatorSection = buildPacketSeenTooltipSection({
+                                                                firstSeenAt:
+                                                                        tracerouteInitiatorNode?.traceroutes_first_seen_at,
+                                                                lastSeenAt:
+                                                                        tracerouteInitiatorNode?.traceroutes_updated_at,
+                                                                packetTypeLabel: "Pacchetti traceroute ricevuti",
+                                                                sourceName: getNodeDisplayLabel(
+                                                                        tracerouteInitiatorNode,
+                                                                        traceroute.from,
+                                                                ),
+                                                                sourceDetail: initiatorDetail,
+                                                                momentLib: moment,
+                                                        });
+
+                                                        if (initiatorSection) {
+                                                                tooltip += initiatorSection;
+                                                        }
+                                                }
+
+                                                if (
                                                         traceroute.to != null &&
-                                                        traceroute.to === traceroute.from
-                                                                ? "(nodo che ha avviato e risposto al traceroute)"
-                                                                : "(nodo che ha avviato il traceroute)";
-                                                const initiatorSection = buildPacketSeenTooltipSection({
-                                                        firstSeenAt:
-                                                                tracerouteInitiatorNode?.traceroutes_first_seen_at,
-                                                        lastSeenAt:
-                                                                tracerouteInitiatorNode?.traceroutes_updated_at,
-                                                        packetTypeLabel: "Pacchetti traceroute ricevuti",
-                                                        sourceName: getNodeDisplayLabel(
-                                                                tracerouteInitiatorNode,
-                                                                traceroute.from,
-                                                        ),
-                                                        sourceDetail: initiatorDetail,
-                                                        momentLib: moment,
-                                                });
+                                                        traceroute.to !== traceroute.from
+                                                ) {
+                                                        const tracerouteDestinationNode = findNodeById(traceroute.to);
+                                                        const destinationSection = buildPacketSeenTooltipSection({
+                                                                firstSeenAt:
+                                                                        tracerouteDestinationNode?.traceroutes_first_seen_at,
+                                                                lastSeenAt:
+                                                                        tracerouteDestinationNode?.traceroutes_updated_at,
+                                                                packetTypeLabel: "Pacchetti traceroute ricevuti",
+                                                                sourceName: getNodeDisplayLabel(
+                                                                        tracerouteDestinationNode,
+                                                                        traceroute.to,
+                                                                ),
+                                                                sourceDetail: "(nodo destinazione del traceroute)",
+                                                                momentLib: moment,
+                                                        });
 
-                                                if (initiatorSection) {
-                                                        tooltip += initiatorSection;
+                                                        if (destinationSection) {
+                                                                tooltip += destinationSection;
+                                                        }
                                                 }
-                                        }
-
-                                        if (
-                                                traceroute.to != null &&
-                                                traceroute.to !== traceroute.from
-                                        ) {
-                                                const tracerouteDestinationNode = findNodeById(traceroute.to);
-                                                const destinationSection = buildPacketSeenTooltipSection({
-                                                        firstSeenAt:
-                                                                tracerouteDestinationNode?.traceroutes_first_seen_at,
-                                                        lastSeenAt:
-                                                                tracerouteDestinationNode?.traceroutes_updated_at,
-                                                        packetTypeLabel: "Pacchetti traceroute ricevuti",
-                                                        sourceName: getNodeDisplayLabel(
-                                                                tracerouteDestinationNode,
-                                                                traceroute.to,
-                                                        ),
-                                                        sourceDetail: "(nodo destinazione del traceroute)",
-                                                        momentLib: moment,
-                                                });
-
-                                                if (destinationSection) {
-                                                        tooltip += destinationSection;
+                                                tooltip += `<br/><br/>${tooltipRoute}`;
+                                                tooltip += `<br/>Salti: ${hopCount}`;
+                                                if (traceroute.total_distance_label) {
+                                                        tooltip += `<br/>Distanza totale: ${escapeString(traceroute.total_distance_label)}`;
                                                 }
-                                        }
-                                        tooltip += `<br/><br/>${tooltipRoute}`;
-                                        tooltip += `<br/>Salti: ${hopCount}`;
-                                        if (traceroute.total_distance_label) {
-                                                tooltip += `<br/>Distanza totale: ${escapeString(traceroute.total_distance_label)}`;
-                                        }
 
-                                        const snrTowardsLabel =
-                                                quality.snrTowardsLabel ?? "N/D";
-                                        const snrBackLabel =
-                                                quality.snrBackLabel ?? "N/D";
-                                        tooltip += `<br/>SNR andata: ${escapeString(snrTowardsLabel)}`;
-                                        tooltip += `<br/>SNR ritorno: ${escapeString(snrBackLabel)}`;
+                                                const snrTowardsLabel =
+                                                        quality.snrTowardsLabel ?? "N/D";
+                                                const snrBackLabel =
+                                                        quality.snrBackLabel ?? "N/D";
+                                                tooltip += `<br/>SNR andata: ${escapeString(snrTowardsLabel)}`;
+                                                tooltip += `<br/>SNR ritorno: ${escapeString(snrBackLabel)}`;
 
-                                        if (traceroute.channel_id) {
-                                                tooltip += `<br/>Canale MQTT: ${escapeString(traceroute.channel_id)}`;
-                                        }
+                                                if (traceroute.channel_id) {
+                                                        tooltip += `<br/>Canale MQTT: ${escapeString(traceroute.channel_id)}`;
+                                                }
 
-                                        if (traceroute.channel != null) {
-                                                tooltip += `<br/>Canale: ${escapeString(String(traceroute.channel))}`;
-                                        }
+                                                if (traceroute.channel != null) {
+                                                        tooltip += `<br/>Canale: ${escapeString(String(traceroute.channel))}`;
+                                                }
 
-                                        if (traceroute.gateway_id != null) {
-                                                const gatewayNode = findNodeById(traceroute.gateway_id);
-                                                const gatewayLabel = gatewayNode
-                                                        ? `[${escapeString(gatewayNode.short_name)}] ${escapeString(gatewayNode.long_name)}`
-                                                        : `Nodo ${formatNodeIdAsHex(traceroute.gateway_id)}`;
-                                                tooltip += `<br/>Instradato su MQTT da: ${gatewayLabel}`;
-                                        }
+                                                if (traceroute.gateway_id != null) {
+                                                        const gatewayNode = findNodeById(traceroute.gateway_id);
+                                                        const gatewayLabel = gatewayNode
+                                                                ? `[${escapeString(gatewayNode.short_name)}] ${escapeString(gatewayNode.long_name)}`
+                                                                : `Nodo ${formatNodeIdAsHex(traceroute.gateway_id)}`;
+                                                        tooltip += `<br/>Instradato su MQTT da: ${gatewayLabel}`;
+                                                }
 
-                                        if (quality.isMqtt) {
-                                                tooltip += `<br/>Qualità: Pacchetto MQTT`;
-                                        }
+                                                if (quality.isMqtt) {
+                                                        tooltip += `<br/>Qualità: Pacchetto MQTT`;
+                                                }
+
+                                                return tooltip;
+                                        };
+
+                                        const initialTooltipContent = buildTracerouteTooltipContent();
 
                                         const segments = [];
                                         let currentSegment = [];
@@ -5954,13 +6099,75 @@
                                                         })
                                                         .addTo(traceroutesLayerGroup);
 
+                                                let tracerouteTooltipRefreshIntervalId = null;
+
+                                                function stopTracerouteTooltipContentUpdates() {
+                                                        if (tracerouteTooltipRefreshIntervalId != null) {
+                                                                window.clearInterval(tracerouteTooltipRefreshIntervalId);
+                                                                tracerouteTooltipRefreshIntervalId = null;
+                                                        }
+                                                }
+
+                                                function refreshTracerouteTooltipContent() {
+                                                        const updatedContent = buildTracerouteTooltipContent();
+
+                                                        if (typeof line.setTooltipContent === "function") {
+                                                                line.setTooltipContent(updatedContent);
+                                                        }
+
+                                                        const tooltipInstance =
+                                                                typeof line.getTooltip === "function"
+                                                                        ? line.getTooltip()
+                                                                        : null;
+                                                        if (tooltipInstance?.setContent) {
+                                                                tooltipInstance.setContent(updatedContent);
+                                                        }
+
+                                                        if (typeof line.setPopupContent === "function") {
+                                                                line.setPopupContent(updatedContent);
+                                                        }
+
+                                                        const popupInstance =
+                                                                typeof line.getPopup === "function" ? line.getPopup() : null;
+                                                        if (popupInstance?.isOpen?.() && popupInstance?.setContent) {
+                                                                popupInstance.setContent(updatedContent);
+                                                        }
+
+                                                        return updatedContent;
+                                                }
+
+                                                function startTracerouteTooltipContentUpdates() {
+                                                        stopTracerouteTooltipContentUpdates();
+                                                        tracerouteTooltipRefreshIntervalId = window.setInterval(
+                                                                refreshTracerouteTooltipContent,
+                                                                30 * 1000,
+                                                        );
+                                                }
+
                                                 line
-                                                        .bindTooltip(tooltip, {
+                                                        .bindTooltip(initialTooltipContent, {
                                                                 sticky: true,
                                                                 opacity: 1,
                                                                 interactive: true,
                                                         })
-                                                        .bindPopup(tooltip)
+                                                        .bindPopup(initialTooltipContent)
+                                                        .on("tooltipopen", function () {
+                                                                refreshTracerouteTooltipContent();
+                                                                startTracerouteTooltipContentUpdates();
+                                                        })
+                                                        .on("tooltipclose", function () {
+                                                                stopTracerouteTooltipContentUpdates();
+                                                        })
+                                                        .on("popupopen", function () {
+                                                                refreshTracerouteTooltipContent();
+                                                                startTracerouteTooltipContentUpdates();
+                                                        })
+                                                        .on("popupclose", function () {
+                                                                stopTracerouteTooltipContentUpdates();
+                                                        })
+                                                        .on("remove", function () {
+                                                                stopTracerouteTooltipContentUpdates();
+                                                        })
                                                         .on("click", function (event) {
                                                                 event.target.closeTooltip();
                                                         });
@@ -5969,11 +6176,15 @@
                         }
 
                         function onTraceroutesUpdated(updatedTraceroutes) {
+                                const ageRetrievedAtMs = Date.now();
+                                const ageRetrievedAt = new Date(ageRetrievedAtMs).toISOString();
                                 traceroutes = Array.isArray(updatedTraceroutes)
                                         ? updatedTraceroutes.map((traceroute) => {
                                                 const quality = calculateTracerouteQualityMetrics(traceroute);
                                                 return {
                                                         ...traceroute,
+                                                        age_in_seconds_retrieved_at: ageRetrievedAt,
+                                                        age_in_seconds_retrieved_at_ms: ageRetrievedAtMs,
                                                         is_mqtt: quality.isMqtt,
                                                         snr_towards_label: quality.snrTowardsLabel ?? null,
                                                         snr_back_label: quality.snrBackLabel ?? null,
@@ -6245,6 +6456,21 @@
                                                         const rssiLabel =
                                                                 neighbourQuality.rssiLabel ?? "N/D";
 
+                                                        const neighbourTimestamps = getNeighbourConnectionTimestamps({
+                                                                neighbour: neighbour,
+                                                                sourceNode: node,
+                                                                targetNode: neighbourNode,
+                                                        });
+
+                                                        const neighbourFirstSeenLabel = formatRelativeAndExactTimestampLabel(
+                                                                neighbourTimestamps.firstSeenAt,
+                                                                moment,
+                                                        );
+                                                        const neighbourUpdatedLabel = formatRelativeAndExactTimestampLabel(
+                                                                neighbourTimestamps.updatedAt,
+                                                                moment,
+                                                        );
+
                                                         let tooltip = `<b>[${escapeString(node.short_name)}] ${escapeString(node.long_name)}</b> heard <b>[${escapeString(neighbourNode.short_name)}] ${escapeString(neighbourNode.long_name)}</b>`;
                                                         tooltip += `<br/>SNR (ricezione): ${escapeString(snrLabel)}`;
                                                         tooltip += `<br/>RSSI (ricezione): ${escapeString(rssiLabel)}`;
@@ -6252,21 +6478,21 @@
                                                         tooltip += `<br/><br/>ID: ${node.node_id} heard ${neighbourNode.node_id}`;
                                                         tooltip += `<br/>ID esadecimale: ${node.node_id_hex} heard ${neighbourNode.node_id_hex}`;
 
-                                                        const nodeFirstSeenLabel = formatRelativeAndExactTimestampLabel(
-                                                                node.neighbours_first_seen_at,
-                                                                moment,
-                                                        );
-                                                        if (nodeFirstSeenLabel) {
-                                                                tooltip += `<br/>Prima info: ${nodeFirstSeenLabel}`;
+                                                        if (neighbourFirstSeenLabel) {
+                                                                tooltip += `<br/>Creazione vicini: ${escapeString(neighbourFirstSeenLabel)}`;
                                                         }
 
-                                                        const nodeUpdatedLabel = formatRelativeAndExactTimestampLabel(
-                                                                node.neighbours_updated_at,
-                                                                moment,
-                                                        );
-                                                        if (nodeUpdatedLabel) {
-                                                                tooltip += `<br/>Aggiornamento: ${nodeUpdatedLabel}`;
+                                                        if (neighbourUpdatedLabel) {
+                                                                tooltip += `<br/>Ultimo aggiornamento vicini: ${escapeString(neighbourUpdatedLabel)}`;
                                                         }
+
+                                                        tooltip += buildPacketSeenTooltipSection({
+                                                                firstSeenAt: neighbourTimestamps.firstSeenAt,
+                                                                lastSeenAt: neighbourTimestamps.updatedAt,
+                                                                packetTypeLabel: "Pacchetti vicini ricevuti",
+                                                                sourceName: getNodeDisplayLabel(node, node.node_id),
+                                                                momentLib: moment,
+                                                        });
 
                                                         if (neighbourQuality.isMqtt) {
                                                                 tooltip += `<br/>Qualità: Pacchetto MQTT`;
@@ -6275,17 +6501,17 @@
                                                         tooltip += `<br/><br/>Terrain images from <a href="http://www.heywhatsthat.com" target="_blank">HeyWhatsThat.com</a>`;
                                                         tooltip += `<br/><a href="${terrainImageUrl}" target="_blank"><img src="${terrainImageUrl}" width="100%"></a>`;
 
-							line
-								.bindTooltip(tooltip, {
-									sticky: true,
-									opacity: 1,
-									interactive: true,
-								})
-								.bindPopup(tooltip)
-								.on("click", function (event) {
-									// close tooltip on click to prevent tooltip and popup showing at same time
-									event.target.closeTooltip();
-								});
+                                                        line
+                                                                .bindTooltip(tooltip, {
+                                                                        sticky: true,
+                                                                        opacity: 1,
+                                                                        interactive: true,
+                                                                })
+                                                                .bindPopup(tooltip)
+                                                                .on("click", function (event) {
+                                                                        // close tooltip on click to prevent tooltip and popup showing at same time
+                                                                        event.target.closeTooltip();
+                                                                });
 						}
 					}
 				}


### PR DESCRIPTION
## Summary
- show traceroute tooltip creation and last update timestamps with explicit labels so hover popups mirror sidebar details
- include seconds and UTC offset in timestamp helper so traceroute, node, and neighbour metadata display precise event times
- extend neighbour overlays and modals to surface connection creation/last update timestamps using shared timestamp helpers

## Testing
- not run (tests not provided)


------
https://chatgpt.com/codex/tasks/task_e_68de6bef44ac8323a15cb596e6e3898a